### PR TITLE
Fixed issue where entirely numeric readcodes are mangled by excel

### DIFF
--- a/shared/Long-term conditions/Cardiovascular/Hypertension - CTV3.txt
+++ b/shared/Long-term conditions/Cardiovascular/Hypertension - CTV3.txt
@@ -1,12 +1,12 @@
 CTV3ID	CTV3PreferredTermDesc	CTV3Source
 14A2.	H/O: hypertension	CTV3Map_Code_And_Term
 21261	Hypertension resolved	QOF
-2466	O/E - BP reading raised	QOF
-2467	O/E - BP reading very high	QOF
+2466.	O/E - BP reading raised	QOF
+2467.	O/E - BP reading very high	QOF
 662..	Cardiac disease monitoring (& [hypertension])	CTV3_Children
-6627	Good hypertension control	CTV3Map_Code_And_Term
-6628	Poor hypertension control	CTV3Map_Code_And_Term
-6629	Hypertension:follow-up default	CTV3Map_Code_And_Term
+6627.	Good hypertension control	CTV3Map_Code_And_Term
+6628.	Poor hypertension control	CTV3Map_Code_And_Term
+6629.	Hypertension:follow-up default	CTV3Map_Code_And_Term
 662F.	Hypertension treatm. started	CTV3Map_Code_And_Term
 662G.	Hypertensive treatm.changed	CTV3Map_Code_And_Term
 662H.	Hypertension treatm.stopped	CTV3Map_Code_And_Term

--- a/shared/Long-term conditions/Endocrine/Diabetes - CTV3.txt
+++ b/shared/Long-term conditions/Endocrine/Diabetes - CTV3.txt
@@ -1,6 +1,6 @@
 CTV3ID	CTV3PreferredTermDesc	CTV3Source
 13B1.	Diabetic diet	High_Level_SNOMED
-1434	H/O: diabetes mellitus	High_Level_SNOMED
+1434.	H/O: diabetes mellitus	High_Level_SNOMED
 14P3.	H/O: insulin therapy	CTV3Map_Code_And_Term
 42W1.	Hb. A1C < 7% - good control	CTV3_Children
 42W2.	Hb. A1C 7-10% - borderline	CTV3_Children

--- a/shared/Long-term conditions/Endocrine/Diabetes - Readv2.txt
+++ b/shared/Long-term conditions/Endocrine/Diabetes - Readv2.txt
@@ -22,7 +22,7 @@ medcode	readcode	Description	CodingSystem
 5884	C109.11	NIDDM - Non-insulin dependent diabetes mellitus	readcode
 6509	C108700	Insulin dependent diabetes mellitus with retinopathy	readcode
 6791	C108800	Insulin dependent diabetes mellitus - poor control	readcode
-6813	1434	H/O: diabetes mellitus	readcode
+6813	1434.00	H/O: diabetes mellitus	readcode
 7563	66A3.00	Diabetic on diet only	readcode
 7795	C106.12	Diabetes mellitus with neuropathy	readcode
 8403	C109700	Non-insulin dependent diabetes mellitus - poor control	readcode

--- a/shared/Long-term conditions/Gastrointestinal/Chronic Liver Disease - CTV3.txt
+++ b/shared/Long-term conditions/Gastrointestinal/Chronic Liver Disease - CTV3.txt
@@ -1,5 +1,5 @@
 CTV3ID	CTV3PreferredTermDesc	CTV3Source
-7609	Open operations on oesophageal varices	CTV3Map_Code_And_Term
+7609.	Open operations on oesophageal varices	CTV3Map_Code_And_Term
 76093	Local ligation of oesophageal varices	CTV3Map_Code_And_Term
 76094	Open injection sclerotherapy to oesophageal varices	CTV3Map_Code_And_Term
 7609y	Oesophageal varices operation: [OS open] or [Tanner]	CTV3_Children
@@ -9,7 +9,7 @@ CTV3ID	CTV3PreferredTermDesc	CTV3Source
 760F3	Rigid oesophagoscopy and injection sclerotherapy of varices	CTV3Map_Code_And_Term
 760F4	Rigid oesophagoscopy and banding of oesophageal varices	CTV3Map_Code_And_Term
 760J4	Balloon tamponade of oesophagus	CTV3Map_Code_And_Term
-7800	Liver transplant	CTV3Map_Code_And_Term
+7800.	Liver transplant	CTV3Map_Code_And_Term
 78000	Orthotopic liver transplant	CTV3Map_Code_And_Term
 78001	Heterotopic liver transplant	CTV3Map_Code_And_Term
 78001	Heterotopic liver transplant	CTV3Map_Code_Only

--- a/shared/Long-term conditions/Gastrointestinal/Chronic Liver Disease and Viral Hepatitis - Readv2.txt
+++ b/shared/Long-term conditions/Gastrointestinal/Chronic Liver Disease and Viral Hepatitis - Readv2.txt
@@ -39,7 +39,7 @@ medcode	readcode	Description	CodingSystem
 21713	J612000	Alcoholic fibrosis and sclerosis of liver	readcode
 22841	J615z11	Macronodular cirrhosis of liver	readcode
 23578	J614000	Chronic persistent hepatitis	readcode
-24220	7609	Open operations on oesophageal varices	readcode
+24220	7609.00	Open operations on oesophageal varices	readcode
 24813	A707000	Chronic viral hepatitis B with delta-agent	readcode
 24989	G850.00	Oesophageal varices with bleeding	readcode
 25383	J61y400	Hepatic fibrosis	readcode

--- a/shared/Long-term conditions/Gastrointestinal/Peptic Ulcer Disease - Readv2.txt
+++ b/shared/Long-term conditions/Gastrointestinal/Peptic Ulcer Disease - Readv2.txt
@@ -8,7 +8,7 @@ medcode	readcode	Description	CodingSystem
 3462	J123.00	Duodenal erosion	readcode
 4741	7627000	Closure of perforated duodenal ulcer	readcode
 5521	J130200	Acute peptic ulcer with perforation	readcode
-5928	7627	Operations on duodenal ulcer	readcode
+5928	7627..	Operations on duodenal ulcer	readcode
 6333	J11..11	Prepyloric ulcer	readcode
 6865	761J.11	Stomach ulcer operations	readcode
 9853	J121.00	Chronic duodenal ulcer	readcode
@@ -99,25 +99,25 @@ medcode	readcode	Description	CodingSystem
 73338	J11y000	Unspecified gastric ulcer without mention of complication	readcode
 73417	J120400	Acute duodenal ulcer with obstruction	readcode
 73697	J11y400	Unspecified gastric ulcer with obstruction	readcode
-74496	5329		readcode
-74539	5329PT		readcode
-74848	5320		readcode
-75354	5319TM		readcode
-75550	5319PP		readcode
-75673	5339		readcode
-76394	5339DB		readcode
-77740	5329BD		readcode
-79977	5310		readcode
-82043	5349MR		readcode
-82405	5330		readcode
-83017	5319PT		readcode
-83963	5310PT		readcode
-84227	K4271		readcode
-88061	5349GJ		readcode
-88070	5320PT		readcode
-88195	5310TM		readcode
-90208	5340GJ		readcode
-90899	K458 PT		readcode
+74496	5329		OXMIS
+74539	5329PT		OXMIS
+74848	5320		OXMIS
+75354	5319TM		OXMIS
+75550	5319PP		OXMIS
+75673	5339		OXMIS
+76394	5339DB		OXMIS
+77740	5329BD		OXMIS
+79977	5310		OXMIS
+82043	5349MR		OXMIS
+82405	5330		OXMIS
+83017	5319PT		OXMIS
+83963	5310PT		OXMIS
+84227	K4271		OXMIS
+88061	5349GJ		OXMIS
+88070	5320PT		OXMIS
+88195	5310TM		OXMIS
+90208	5340GJ		OXMIS
+90899	K458 PT		OXMIS
 92695	7612111	Balfour excision of gastric ulcer	readcode
 93436	J12y300	Unspecified duodenal ulcer with haemorrhage and perforation	readcode
 94104	761Jy00	Other specified operation on gastric ulcer	readcode

--- a/shared/Long-term conditions/Gastrointestinal/Peptic ulcer disease - CTV3.txt
+++ b/shared/Long-term conditions/Gastrointestinal/Peptic ulcer disease - CTV3.txt
@@ -109,7 +109,7 @@ J12..	Duodenal ulcer	CTV3Map_Code_And_Term
 J12z.	Duodenal ulcer NOS	CTV3Map_Code_And_Term
 J122.	Duodenal ulcer disease	CTV3_Children
 X302b	Duodenal ulcer disease	CTV3Map_Code_And_Term
-7627	Duodenal ulcer operation	CTV3Map_Code_And_Term
+7627.	Duodenal ulcer operation	CTV3Map_Code_And_Term
 XaFBq	Endoscopic injection haemostasis of duodenal ulcer	CTV3Map_Code_And_Term
 XaFBs	Endoscopic injection haemostasis of gastric ulcer	CTV3Map_Code_And_Term
 X300K	Eosinophilic ulcer of oesophagus	CTV3_Children
@@ -189,7 +189,7 @@ J13z.	Peptic ulcer NOS	CTV3Map_Code_And_Term
 XM0BZ	Peptic ulcer disease	High_Level_SNOMED
 X302c	Peptic ulcer of duodenum	CTV3_Children
 X302X	Peptic ulcer of stomach	High_Level_SNOMED
-1956	Peptic ulcer symptoms	CTV3Map_Code_And_Term
+1956.	Peptic ulcer symptoms	CTV3Map_Code_And_Term
 XE0c1	Perforated DU (& [acute])	High_Level_SNOMED
 XE0bz	Perforated GU (& [acute])	CTV3_Children
 XM0sI	Perforated peptic ulcer	High_Level_SNOMED

--- a/shared/Long-term conditions/Psychiatric/Dementia - Readv2.txt
+++ b/shared/Long-term conditions/Psychiatric/Dementia - Readv2.txt
@@ -4,7 +4,7 @@ medcode	readcode	Description	CodingSystem
 1917	F110.00	Alzheimer's disease	readcode
 4357	Eu02z14	[X] Senile dementia NOS	readcode
 4693	Eu02z00	[X] Unspecified dementia	readcode
-5931	1461	H/O: dementia	readcode
+5931	1461.00	H/O: dementia	readcode
 6578	Eu01.00	[X]Vascular dementia	readcode
 7323	E000.00	Uncomplicated senile dementia	readcode
 7572	F116.00	Lewy body disease	readcode

--- a/shared/Long-term conditions/Psychiatric/Depression MEDCODES - Readv2.txt
+++ b/shared/Long-term conditions/Psychiatric/Depression MEDCODES - Readv2.txt
@@ -6,10 +6,10 @@ medcode	readcode	Description	CodingSystem
 1055	E135.00	Agitated depression	readcode
 1131	E204.00	Neurotic depression reactive type	readcode
 1533	E290.00	Brief depressive reaction	readcode
-1908	2257	O/E - depressed	readcode
+1908	2257.00	O/E - depressed	readcode
 1996	1B17.00	Depressed	readcode
 2639	E204.11	Postnatal depression	readcode
-2716	1465	H/O: depression	readcode
+2716	1465.00	H/O: depression	readcode
 2923	62T1.00	Puerperal depression	readcode
 2970	Eu32z00	"[X]Depressive episode, unspecified"	readcode
 2972	E2B0.00	Postviral depression	readcode

--- a/shared/Long-term conditions/Renal or Urological/Chronic Kidney Disease - CTV3.txt
+++ b/shared/Long-term conditions/Renal or Urological/Chronic Kidney Disease - CTV3.txt
@@ -29,8 +29,8 @@ CTV3ID	CTV3PreferredTermDesc	CTV3Source
 7L1C0	Insertion of temporary peritoneal dialysis catheter	CTV3Map_Code_And_Term
 7L1Cy	Placement other apparatus- compensate for renal failure OS	CTV3Map_Code_And_Term
 7L1Cz	Placement other apparatus- compensate for renal failure NOS	CTV3Map_Code_And_Term
-8877	Ultrafiltration	CTV3_Children
-8882	Intestinal dialysis	High_Level_SNOMED
+8877.	Ultrafiltration	CTV3_Children
+8882.	Intestinal dialysis	High_Level_SNOMED
 G760.	Acquired arteriovenous fistula	CTV3Map_Code_And_Term
 TA020	"Accid cut,puncture,perf,h'ge - kidney dialysis"	CTV3Map_Code_And_Term
 TA020	"Accid cut,puncture,perf,h'ge - kidney dialysis"	CTV3Map_Code_Only

--- a/shared/Long-term conditions/Respiratory/Asthma (currently treated) MEDCODES - Readv2.txt
+++ b/shared/Long-term conditions/Respiratory/Asthma (currently treated) MEDCODES - Readv2.txt
@@ -38,7 +38,7 @@ medcode	readcode	Description	CodingSystem
 32727	H33z.11	Hyperreactive airways disease	readcode
 39478	H35y700	Wood asthma	readcode
 40823	H334.00	Brittle asthma	readcode
-41017	1780	Aspirin induced asthma	readcode
+41017	1780.00	Aspirin induced asthma	readcode
 45073	H331z00	Intrinsic asthma NOS	readcode
 45782	H330z00	Extrinsic asthma NOS	readcode
 47684	H47y000	Detergent asthma	readcode

--- a/shared/Long-term conditions/Respiratory/Asthma Diagnosis - CTV3.txt
+++ b/shared/Long-term conditions/Respiratory/Asthma Diagnosis - CTV3.txt
@@ -31,20 +31,20 @@ CTV3ID	CTV3PreferredTermDesc	CTV3Source
 663d.	Emergency asthma admission since last appointment	CTV3Map_Code_And_Term
 663e.	Asthma restricts exercise	CTV3Map_Code_And_Term
 663e.	Asthma restricts exercise	QOF
-6.63E+02	Asthma sometimes restricts exercise	CTV3Map_Code_And_Term
-6.63E+02	Asthma sometimes restricts exercise	QOF
-6.63E+03	Asthma severely restricts exercise	CTV3Map_Code_And_Term
-6.63E+03	Asthma severely restricts exercise	QOF
+663e2	Asthma sometimes restricts exercise	CTV3Map_Code_And_Term
+663e2	Asthma sometimes restricts exercise	QOF
+663e3	Asthma severely restricts exercise	CTV3Map_Code_And_Term
+663e3	Asthma severely restricts exercise	QOF
 663f.	Asthma never restricts exercise	CTV3Map_Code_And_Term
 663f.	Asthma never restricts exercise	QOF
 679J.	Health education - asthma	High_Level_SNOMED
-8791	Further asthma - drug prevention	CTV3Map_Code_And_Term
-8793	Asthma control step 0	High_Level_SNOMED
-8794	Asthma control step 1	CTV3Map_Code_And_Term
-8795	Asthma control step 2	CTV3Map_Code_And_Term
-8796	Asthma control step 3	CTV3Map_Code_And_Term
-8797	Asthma control step 4	CTV3Map_Code_And_Term
-8798	Asthma control step 5	CTV3Map_Code_And_Term
+8791.	Further asthma - drug prevention	CTV3Map_Code_And_Term
+8793.	Asthma control step 0	High_Level_SNOMED
+8794.	Asthma control step 1	CTV3Map_Code_And_Term
+8795.	Asthma control step 2	CTV3Map_Code_And_Term
+8796.	Asthma control step 3	CTV3Map_Code_And_Term
+8797.	Asthma control step 4	CTV3Map_Code_And_Term
+8798.	Asthma control step 5	CTV3Map_Code_And_Term
 8H2P.	"Emergency admission, asthma"	CTV3Map_Code_And_Term
 8H2P.	"Emergency admission, asthma"	QOF
 9OJ1.	Attends asthma monitoring	CTV3Map_Code_And_Term


### PR DESCRIPTION
Some readcodes are only contain numbers and trailing "."s. E.g. (2466.	O/E - BP reading raised). When opened and saved from excel (or others) the trailing "."s are omitted resulting in a code which is no longer a read code. A similar issue occurs for codes like (663e2	Asthma sometimes restricts exercise) which excel interprets as an exponent e.g. 663x10^2. I have gone through and corrected all these.

I have also amended the peptic ulcer file where some OXMIS codes were incorrectly classified as Readv2.