### PR TITLE
Ensure no duplicates by adding DISTINCT

### DIFF
--- a/projects/025 - Watkinson/extraction-sql/objectives-1-5.sql
+++ b/projects/025 - Watkinson/extraction-sql/objectives-1-5.sql
@@ -37,7 +37,7 @@ WHERE (DeathDate IS NULL OR DeathDate >= @StartDate);
 
 -- Find all patients registered with a GP
 IF OBJECT_ID('tempdb..#PatientsWithGP') IS NOT NULL DROP TABLE #PatientsWithGP;
-SELECT FK_Patient_Link_ID INTO #PatientsWithGP FROM [RLS].vw_Patient
+SELECT DISTINCT FK_Patient_Link_ID INTO #PatientsWithGP FROM [RLS].vw_Patient
 where FK_Reference_Tenancy_ID = 2;
 
 -- Make cohort from patients alive at start date and registered with a GP

--- a/projects/025 - Watkinson/template-sql/objectives-1-5.template.sql
+++ b/projects/025 - Watkinson/template-sql/objectives-1-5.template.sql
@@ -37,7 +37,7 @@ WHERE (DeathDate IS NULL OR DeathDate >= @StartDate);
 
 -- Find all patients registered with a GP
 IF OBJECT_ID('tempdb..#PatientsWithGP') IS NOT NULL DROP TABLE #PatientsWithGP;
-SELECT FK_Patient_Link_ID INTO #PatientsWithGP FROM [RLS].vw_Patient
+SELECT DISTINCT FK_Patient_Link_ID INTO #PatientsWithGP FROM [RLS].vw_Patient
 where FK_Reference_Tenancy_ID = 2;
 
 -- Make cohort from patients alive at start date and registered with a GP


### PR DESCRIPTION
The Patient table can contain multiple FK_Patient_Link_Ids per patient - even if you restrict the tenancy to just the GP feed (tenancy id = 2). Adding the DISTINCT keyword prevents these duplicate patients.