### PR TITLE
Get LSOA for matched patient rather than cohort patient

### DIFF
--- a/projects/020 - Heald/template-sql/cohort.template.sql
+++ b/projects/020 - Heald/template-sql/cohort.template.sql
@@ -134,7 +134,7 @@ SELECT
   PatientId AS PatientWhoIsMatched
 INTO #MatchedCohort
 FROM #CohortStore c
-LEFT OUTER JOIN #PatientLSOA lsoa ON lsoa.FK_Patient_Link_ID = c.PatientId
+LEFT OUTER JOIN #PatientLSOA lsoa ON lsoa.FK_Patient_Link_ID = c.MatchingPatientId
 WHERE c.PatientId IN (SELECT FK_Patient_Link_ID FROM #DiabeticPatients);
 
 -- Define a table with all the patient ids and index dates for the main cohort and the matched cohort


### PR DESCRIPTION
By linking on the incorrect patientid we were returning the cohort patients LSOA for all of their matches. Now corrected.