### PR TITLE
Distinguish meds between covid vacs and not

### DIFF
--- a/projects/001 - Grant/README.html
+++ b/projects/001 - Grant/README.html
@@ -355,7 +355,7 @@ Prior to data extraction, the code is checked and signed off by another RDE.</p>
   - start-date: string - (YYYY-MM-DD) the date to count diagnoses from. Usually this should be 2020-01-01.
 </code></pre>
 <p><em>Output</em></p>
-<pre><code>Two temp table as follows:
+<pre><code>Two temp tables as follows:
  #CovidPatients (FK_Patient_Link_ID, FirstCovidPositiveDate)
  	- FK_Patient_Link_ID - unique patient id
 	- FirstCovidPositiveDate - earliest COVID diagnosis

--- a/projects/001 - Grant/README.md
+++ b/projects/001 - Grant/README.md
@@ -328,7 +328,7 @@ Takes one parameter
 
 _Output_
 ```
-Two temp table as follows:
+Two temp tables as follows:
  #CovidPatients (FK_Patient_Link_ID, FirstCovidPositiveDate)
  	- FK_Patient_Link_ID - unique patient id
 	- FirstCovidPositiveDate - earliest COVID diagnosis

--- a/projects/001 - Grant/extraction-sql/primary-utilisation-file-3.sql
+++ b/projects/001 - Grant/extraction-sql/primary-utilisation-file-3.sql
@@ -1024,7 +1024,7 @@ HAVING MIN(IMD2019Decile1IsMostDeprived10IsLeastDeprived) = MAX(IMD2019Decile1Is
 -- INPUT: Takes one parameter
 --  - start-date: string - (YYYY-MM-DD) the date to count diagnoses from. Usually this should be 2020-01-01.
 
--- OUTPUT: Two temp table as follows:
+-- OUTPUT: Two temp tables as follows:
 -- #CovidPatients (FK_Patient_Link_ID, FirstCovidPositiveDate)
 -- 	- FK_Patient_Link_ID - unique patient id
 --	- FirstCovidPositiveDate - earliest COVID diagnosis
@@ -1171,10 +1171,24 @@ LEFT OUTER JOIN #PatientPractice pp ON pp.FK_Patient_Link_ID = p.FK_Patient_Link
 LEFT OUTER JOIN SharedCare.Reference_GP_Practice gp ON gp.OrganisationCode = pp.GPPracticeCode
 LEFT OUTER JOIN #CCGLookup ccg ON ccg.CcgId = gp.Commissioner;
 
+-- We need to remove the main COVID vaccine codes from the medications as they cause
+-- spikes which we're not interested in
+IF OBJECT_ID('tempdb..#COVIDVaccMedCodes') IS NOT NULL DROP TABLE #COVIDVaccMedCodes;
+SELECT 'S'+CONVERT(VARCHAR,FK_Reference_SnomedCT_ID) AS Code INTO #COVIDVaccMedCodes
+FROM SharedCare.Reference_Local_Code
+WHERE LocalCode IN ('COCO138186NEMIS','CODI138564NEMIS','TASO138184NEMIS')
+AND FK_Reference_SnomedCT_ID != -1
+UNION
+SELECT 'F'+CONVERT(VARCHAR,FK_Reference_Coding_ID) FROM SharedCare.Reference_Local_Code
+WHERE LocalCode IN ('COCO138186NEMIS','CODI138564NEMIS','TASO138184NEMIS')
+AND FK_Reference_Coding_ID != -1;
+
 -- Bring it all together for output
 -- PRINT 'FirstMedDate,CCG,GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived,NumberOfLTCs,CovidHealthcareUtilisation,NumberFirstPrescriptions';
 SELECT 
-	fm.FirstMedDate, CCG, GPPracticeCode, 
+	fm.FirstMedDate,
+	'Y' AS IsCovidVaccine,
+	CCG, GPPracticeCode, 
 	ISNULL(IMD2019Decile1IsMostDeprived10IsLeastDeprived, 0) AS IMD2019Decile1IsMostDeprived10IsLeastDeprived, 
 	ISNULL(NumberOfLTCs,0) AS NumberOfLTCs, CovidHealthcareUtilisation, count(*) AS NumberFirstPrescriptions  
 FROM #FirstMedications fm
@@ -1182,5 +1196,20 @@ LEFT OUTER JOIN #COVIDUtilisationPrimaryCare c ON c.FK_Patient_Link_ID = fm.FK_P
 LEFT OUTER JOIN #NumLTCs ltc ON ltc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientIMDDecile imd ON imd.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientPracticeAndCCG pc ON pc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+WHERE fm.Code IN (SELECT Code FROM #COVIDVaccMedCodes)
 GROUP BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, NumberOfLTCs, CovidHealthcareUtilisation
-ORDER BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, NumberOfLTCs, CovidHealthcareUtilisation;
+UNION
+SELECT 
+	fm.FirstMedDate,
+	'N' AS IsCovidVaccine,
+	CCG, GPPracticeCode, 
+	ISNULL(IMD2019Decile1IsMostDeprived10IsLeastDeprived, 0) AS IMD2019Decile1IsMostDeprived10IsLeastDeprived, 
+	ISNULL(NumberOfLTCs,0) AS NumberOfLTCs, CovidHealthcareUtilisation, count(*) AS NumberFirstPrescriptions  
+FROM #FirstMedications fm
+LEFT OUTER JOIN #COVIDUtilisationPrimaryCare c ON c.FK_Patient_Link_ID = fm.FK_Patient_Link_ID AND c.EventDate = fm.FirstMedDate
+LEFT OUTER JOIN #NumLTCs ltc ON ltc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientIMDDecile imd ON imd.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientPracticeAndCCG pc ON pc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+WHERE fm.Code NOT IN (SELECT Code FROM #COVIDVaccMedCodes)
+GROUP BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, NumberOfLTCs, CovidHealthcareUtilisation
+ORDER BY FirstMedDate, IsCovidVaccine, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, NumberOfLTCs, CovidHealthcareUtilisation;

--- a/projects/001 - Grant/extraction-sql/primary-utilisation-file-5.sql
+++ b/projects/001 - Grant/extraction-sql/primary-utilisation-file-5.sql
@@ -50,7 +50,8 @@ IF OBJECT_ID('tempdb..#AllCodes') IS NOT NULL DROP TABLE #AllCodes;
 CREATE TABLE #AllCodes (
   [Concept] [varchar](255) NOT NULL,
   [Version] INT NOT NULL,
-  [Code] [varchar](20) COLLATE Latin1_General_CS_AS NOT NULL
+  [Code] [varchar](20) COLLATE Latin1_General_CS_AS NOT NULL,
+  [description] [varchar] (255) NULL 
 );
 
 IF OBJECT_ID('tempdb..#codesreadv2') IS NOT NULL DROP TABLE #codesreadv2;
@@ -73,7 +74,7 @@ INSERT INTO #codesreadv2
 VALUES ('hba1c',1,'42c..00','HbA1 - diabetic control'),('hba1c',1,'42c..','HbA1 - diabetic control'),('hba1c',1,'42c3.00','HbA1 level (DCCT aligned)'),('hba1c',1,'42c3.','HbA1 level (DCCT aligned)'),('hba1c',1,'42c2.00','HbA1 > 10% - bad control'),('hba1c',1,'42c2.','HbA1 > 10% - bad control'),('hba1c',1,'42c1.00','HbA1 7 - 10% - borderline control'),('hba1c',1,'42c1.','HbA1 7 - 10% - borderline control'),('hba1c',1,'42c0.00','HbA1 < 7% - good control'),('hba1c',1,'42c0.','HbA1 < 7% - good control'),('hba1c',1,'42W..11','Glycosylated Hb'),('hba1c',1,'42W..','Glycosylated Hb'),('hba1c',1,'42W..12','Glycated haemoglobin'),('hba1c',1,'42W..','Glycated haemoglobin'),('hba1c',1,'42W..00','Hb. A1C - diabetic control'),('hba1c',1,'42W..','Hb. A1C - diabetic control'),('hba1c',1,'42WZ.00','Hb. A1C - diabetic control NOS'),('hba1c',1,'42WZ.','Hb. A1C - diabetic control NOS'),('hba1c',1,'42W3.00','Hb. A1C > 10% - bad control'),('hba1c',1,'42W3.','Hb. A1C > 10% - bad control'),('hba1c',1,'42W2.00','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W2.','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W1.00','Hb. A1C < 7% - good control'),('hba1c',1,'42W1.','Hb. A1C < 7% - good control'),('hba1c',1,'42W5.00','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W5100','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W51','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W5000','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W50','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W4.00','HbA1c level (DCCT aligned)'),('hba1c',1,'42W4.','HbA1c level (DCCT aligned)'),('hba1c',1,'44TL.00','Total glycosylated haemoglobin level'),('hba1c',1,'44TL.','Total glycosylated haemoglobin level'),('hba1c',1,'44TB.00','Haemoglobin A1c level'),('hba1c',1,'44TB.','Haemoglobin A1c level'),('hba1c',1,'44TB100','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB1','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB000','Haemoglobin A1c (diagnostic reference range)'),('hba1c',1,'44TB0','Haemoglobin A1c (diagnostic reference range)'),('hba1c',2,'42W5.00','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W4.00','HbA1c level (DCCT aligned)'),('hba1c',2,'42W4.','HbA1c level (DCCT aligned)')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesreadv2;
+SELECT [concept], [version], [code], [description] from #codesreadv2;
 
 IF OBJECT_ID('tempdb..#codesctv3') IS NOT NULL DROP TABLE #codesctv3;
 CREATE TABLE #codesctv3 (
@@ -95,7 +96,7 @@ INSERT INTO #codesctv3
 VALUES ('hba1c',1,'X772q','Haemoglobin A1c level'),('hba1c',1,'XE24t','Hb. A1C - diabetic control'),('hba1c',1,'42W1.','Hb. A1C < 7% - good control'),('hba1c',1,'42W2.','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W3.','Hb. A1C > 10% - bad control'),('hba1c',1,'42WZ.','Hb. A1C - diabetic control NOS'),('hba1c',1,'X80U4','Glycosylat haemoglobin-c frac'),('hba1c',1,'XaCES','HbA1 - diabetic control'),('hba1c',1,'XaCET','HbA1 <7% - good control'),('hba1c',1,'XaCEV','HbA1 >10% - bad control'),('hba1c',1,'XaCEU','HbA1 7-10% - borderline contrl'),('hba1c',1,'XaERp','HbA1c level (DCCT aligned)'),('hba1c',1,'XaPbt','HbA1c levl - IFCC standardised'),('hba1c',1,'XabrE','HbA1c (diagnostic refrn range)'),('hba1c',1,'XabrF','HbA1c (monitoring ranges)'),('hba1c',1,'Xaezd','HbA1c(diagnos ref rnge)IFCC st'),('hba1c',1,'Xaeze','HbA1c(monitoring rnges)IFCC st'),('hba1c',1,'42W..','Hb. A1C - diabetic control'),('hba1c',1,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W51','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W50','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W4.','HbA1c level (DCCT aligned)'),('hba1c',1,'44TB.','Haemoglobin A1c level'),('hba1c',1,'44TB1','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB0','Haemoglobin A1c (diagnostic reference range)'),('hba1c',2,'XaERp','HbA1c level (DCCT aligned)'),('hba1c',2,'XaPbt','HbA1c levl - IFCC standardised'),('hba1c',2,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W4.','HbA1c level (DCCT aligned)')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesctv3;
+SELECT [concept], [version], [code], [description] from #codesctv3;
 
 IF OBJECT_ID('tempdb..#codessnomed') IS NOT NULL DROP TABLE #codessnomed;
 CREATE TABLE #codessnomed (
@@ -119,7 +120,7 @@ INSERT INTO #codessnomed
 VALUES ('hba1c',1,'1019431000000105','HbA1c level (Diabetes Control and Complications Trial aligned)'),('hba1c',1,'1003671000000109','Haemoglobin A1c level'),('hba1c',1,'1049301000000100','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'1049321000000109','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'1107481000000106','HbA1c (haemoglobin A1c) molar concentration in blood'),('hba1c',1,'999791000000106','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'1010941000000103','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'1010951000000100','Haemoglobin A1c (diagnostic reference range)'),('hba1c',1,'165679005','Haemoglobin A1c (HbA1c) less than 7% indicating good diabetic control'),('hba1c',1,'165680008','Haemoglobin A1c (HbA1c) between 7%-10% indicating borderline diabetic control'),('hba1c',1,'165681007','Hemoglobin A1c (HbA1c) greater than 10% indicating poor diabetic control'),('hba1c',1,'365845005','Haemoglobin A1C - diabetic control finding'),('hba1c',1,'444751005','High hemoglobin A1c level'),('hba1c',1,'43396009','Hemoglobin A1c measurement (procedure)'),('hba1c',1,'313835008','Hemoglobin A1c measurement aligned to the Diabetes Control and Complications Trial'),('hba1c',1,'371981000000106','Hb A1c (Haemoglobin A1c) level - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'444257008','Calculation of estimated average glucose based on haemoglobin A1c'),('hba1c',1,'269823000','Haemoglobin A1C - diabetic control interpretation'),('hba1c',1,'443911005','Ordinal level of hemoglobin A1c'),('hba1c',1,'733830002','HbA1c - Glycated haemoglobin-A1c'),('hba1c',2,'1019431000000105','HbA1c level (Diabetes Control and Complications Trial aligned)'),('hba1c',2,'999791000000106','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codessnomed;
+SELECT [concept], [version], [code], [description] from #codessnomed;
 
 IF OBJECT_ID('tempdb..#codesemis') IS NOT NULL DROP TABLE #codesemis;
 CREATE TABLE #codesemis (
@@ -133,15 +134,15 @@ INSERT INTO #codesemis
 VALUES ('bmi',1,'EMISNQBM1','BMI centile')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesemis;
+SELECT [concept], [version], [code], [description] from #codesemis;
 
 
 IF OBJECT_ID('tempdb..#TempRefCodes') IS NOT NULL DROP TABLE #TempRefCodes;
-CREATE TABLE #TempRefCodes (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, version INT NOT NULL);
+CREATE TABLE #TempRefCodes (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, version INT NOT NULL, [description] VARCHAR(255));
 
 -- Read v2 codes
 INSERT INTO #TempRefCodes
-SELECT PK_Reference_Coding_ID, dcr.concept, dcr.[version]
+SELECT PK_Reference_Coding_ID, dcr.concept, dcr.[version], dcr.[description]
 FROM [SharedCare].[Reference_Coding] rc
 INNER JOIN #codesreadv2 dcr on dcr.code = rc.MainCode
 WHERE CodingType='ReadCodeV2'
@@ -149,7 +150,7 @@ and PK_Reference_Coding_ID != -1;
 
 -- CTV3 codes
 INSERT INTO #TempRefCodes
-SELECT PK_Reference_Coding_ID, dcc.concept, dcc.[version]
+SELECT PK_Reference_Coding_ID, dcc.concept, dcc.[version], dcc.[description]
 FROM [SharedCare].[Reference_Coding] rc
 INNER JOIN #codesctv3 dcc on dcc.code = rc.MainCode
 WHERE CodingType='CTV3'
@@ -157,23 +158,23 @@ and PK_Reference_Coding_ID != -1;
 
 -- EMIS codes with a FK Reference Coding ID
 INSERT INTO #TempRefCodes
-SELECT FK_Reference_Coding_ID, ce.concept, ce.[version]
+SELECT FK_Reference_Coding_ID, ce.concept, ce.[version], ce.[description]
 FROM [SharedCare].[Reference_Local_Code] rlc
 INNER JOIN #codesemis ce on ce.code = rlc.LocalCode
 WHERE FK_Reference_Coding_ID != -1;
 
 IF OBJECT_ID('tempdb..#TempSNOMEDRefCodes') IS NOT NULL DROP TABLE #TempSNOMEDRefCodes;
-CREATE TABLE #TempSNOMEDRefCodes (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [version] INT NOT NULL);
+CREATE TABLE #TempSNOMEDRefCodes (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [version] INT NOT NULL, [description] VARCHAR(255));
 
 -- SNOMED codes
 INSERT INTO #TempSNOMEDRefCodes
-SELECT PK_Reference_SnomedCT_ID, dcs.concept, dcs.[version]
+SELECT PK_Reference_SnomedCT_ID, dcs.concept, dcs.[version], dcs.[description]
 FROM SharedCare.Reference_SnomedCT rs
 INNER JOIN #codessnomed dcs on dcs.code = rs.ConceptID;
 
 -- EMIS codes with a FK SNOMED ID but without a FK Reference Coding ID
 INSERT INTO #TempSNOMEDRefCodes
-SELECT FK_Reference_SnomedCT_ID, ce.concept, ce.[version]
+SELECT FK_Reference_SnomedCT_ID, ce.concept, ce.[version], ce.[description]
 FROM [SharedCare].[Reference_Local_Code] rlc
 INNER JOIN #codesemis ce on ce.code = rlc.LocalCode
 WHERE FK_Reference_Coding_ID = -1
@@ -181,16 +182,16 @@ AND FK_Reference_SnomedCT_ID != -1;
 
 -- De-duped tables
 IF OBJECT_ID('tempdb..#CodeSets') IS NOT NULL DROP TABLE #CodeSets;
-CREATE TABLE #CodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL);
+CREATE TABLE #CodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#SnomedSets') IS NOT NULL DROP TABLE #SnomedSets;
-CREATE TABLE #SnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL);
+CREATE TABLE #SnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#VersionedCodeSets') IS NOT NULL DROP TABLE #VersionedCodeSets;
-CREATE TABLE #VersionedCodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT);
+CREATE TABLE #VersionedCodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#VersionedSnomedSets') IS NOT NULL DROP TABLE #VersionedSnomedSets;
-CREATE TABLE #VersionedSnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT);
+CREATE TABLE #VersionedSnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT, [description] VARCHAR(255));
 
 INSERT INTO #VersionedCodeSets
 SELECT DISTINCT * FROM #TempRefCodes;
@@ -199,7 +200,7 @@ INSERT INTO #VersionedSnomedSets
 SELECT DISTINCT * FROM #TempSNOMEDRefCodes;
 
 INSERT INTO #CodeSets
-SELECT FK_Reference_Coding_ID, c.concept
+SELECT FK_Reference_Coding_ID, c.concept, [description]
 FROM #VersionedCodeSets c
 INNER JOIN (
   SELECT concept, MAX(version) AS maxVersion FROM #VersionedCodeSets
@@ -207,7 +208,7 @@ INNER JOIN (
 sub ON sub.concept = c.concept AND c.version = sub.maxVersion;
 
 INSERT INTO #SnomedSets
-SELECT FK_Reference_SnomedCT_ID, c.concept
+SELECT FK_Reference_SnomedCT_ID, c.concept, [description]
 FROM #VersionedSnomedSets c
 INNER JOIN (
   SELECT concept, MAX(version) AS maxVersion FROM #VersionedSnomedSets

--- a/projects/001 - Grant/extraction-sql/primary-utilisation-file-6.sql
+++ b/projects/001 - Grant/extraction-sql/primary-utilisation-file-6.sql
@@ -50,7 +50,8 @@ IF OBJECT_ID('tempdb..#AllCodes') IS NOT NULL DROP TABLE #AllCodes;
 CREATE TABLE #AllCodes (
   [Concept] [varchar](255) NOT NULL,
   [Version] INT NOT NULL,
-  [Code] [varchar](20) COLLATE Latin1_General_CS_AS NOT NULL
+  [Code] [varchar](20) COLLATE Latin1_General_CS_AS NOT NULL,
+  [description] [varchar] (255) NULL 
 );
 
 IF OBJECT_ID('tempdb..#codesreadv2') IS NOT NULL DROP TABLE #codesreadv2;
@@ -73,7 +74,7 @@ INSERT INTO #codesreadv2
 VALUES ('hba1c',1,'42c..00','HbA1 - diabetic control'),('hba1c',1,'42c..','HbA1 - diabetic control'),('hba1c',1,'42c3.00','HbA1 level (DCCT aligned)'),('hba1c',1,'42c3.','HbA1 level (DCCT aligned)'),('hba1c',1,'42c2.00','HbA1 > 10% - bad control'),('hba1c',1,'42c2.','HbA1 > 10% - bad control'),('hba1c',1,'42c1.00','HbA1 7 - 10% - borderline control'),('hba1c',1,'42c1.','HbA1 7 - 10% - borderline control'),('hba1c',1,'42c0.00','HbA1 < 7% - good control'),('hba1c',1,'42c0.','HbA1 < 7% - good control'),('hba1c',1,'42W..11','Glycosylated Hb'),('hba1c',1,'42W..','Glycosylated Hb'),('hba1c',1,'42W..12','Glycated haemoglobin'),('hba1c',1,'42W..','Glycated haemoglobin'),('hba1c',1,'42W..00','Hb. A1C - diabetic control'),('hba1c',1,'42W..','Hb. A1C - diabetic control'),('hba1c',1,'42WZ.00','Hb. A1C - diabetic control NOS'),('hba1c',1,'42WZ.','Hb. A1C - diabetic control NOS'),('hba1c',1,'42W3.00','Hb. A1C > 10% - bad control'),('hba1c',1,'42W3.','Hb. A1C > 10% - bad control'),('hba1c',1,'42W2.00','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W2.','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W1.00','Hb. A1C < 7% - good control'),('hba1c',1,'42W1.','Hb. A1C < 7% - good control'),('hba1c',1,'42W5.00','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W5100','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W51','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W5000','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W50','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W4.00','HbA1c level (DCCT aligned)'),('hba1c',1,'42W4.','HbA1c level (DCCT aligned)'),('hba1c',1,'44TL.00','Total glycosylated haemoglobin level'),('hba1c',1,'44TL.','Total glycosylated haemoglobin level'),('hba1c',1,'44TB.00','Haemoglobin A1c level'),('hba1c',1,'44TB.','Haemoglobin A1c level'),('hba1c',1,'44TB100','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB1','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB000','Haemoglobin A1c (diagnostic reference range)'),('hba1c',1,'44TB0','Haemoglobin A1c (diagnostic reference range)'),('hba1c',2,'42W5.00','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W4.00','HbA1c level (DCCT aligned)'),('hba1c',2,'42W4.','HbA1c level (DCCT aligned)')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesreadv2;
+SELECT [concept], [version], [code], [description] from #codesreadv2;
 
 IF OBJECT_ID('tempdb..#codesctv3') IS NOT NULL DROP TABLE #codesctv3;
 CREATE TABLE #codesctv3 (
@@ -95,7 +96,7 @@ INSERT INTO #codesctv3
 VALUES ('hba1c',1,'X772q','Haemoglobin A1c level'),('hba1c',1,'XE24t','Hb. A1C - diabetic control'),('hba1c',1,'42W1.','Hb. A1C < 7% - good control'),('hba1c',1,'42W2.','Hb. A1C 7-10% - borderline'),('hba1c',1,'42W3.','Hb. A1C > 10% - bad control'),('hba1c',1,'42WZ.','Hb. A1C - diabetic control NOS'),('hba1c',1,'X80U4','Glycosylat haemoglobin-c frac'),('hba1c',1,'XaCES','HbA1 - diabetic control'),('hba1c',1,'XaCET','HbA1 <7% - good control'),('hba1c',1,'XaCEV','HbA1 >10% - bad control'),('hba1c',1,'XaCEU','HbA1 7-10% - borderline contrl'),('hba1c',1,'XaERp','HbA1c level (DCCT aligned)'),('hba1c',1,'XaPbt','HbA1c levl - IFCC standardised'),('hba1c',1,'XabrE','HbA1c (diagnostic refrn range)'),('hba1c',1,'XabrF','HbA1c (monitoring ranges)'),('hba1c',1,'Xaezd','HbA1c(diagnos ref rnge)IFCC st'),('hba1c',1,'Xaeze','HbA1c(monitoring rnges)IFCC st'),('hba1c',1,'42W..','Hb. A1C - diabetic control'),('hba1c',1,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'42W51','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W50','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'42W4.','HbA1c level (DCCT aligned)'),('hba1c',1,'44TB.','Haemoglobin A1c level'),('hba1c',1,'44TB1','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'44TB0','Haemoglobin A1c (diagnostic reference range)'),('hba1c',2,'XaERp','HbA1c level (DCCT aligned)'),('hba1c',2,'XaPbt','HbA1c levl - IFCC standardised'),('hba1c',2,'42W5.','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',2,'42W4.','HbA1c level (DCCT aligned)')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesctv3;
+SELECT [concept], [version], [code], [description] from #codesctv3;
 
 IF OBJECT_ID('tempdb..#codessnomed') IS NOT NULL DROP TABLE #codessnomed;
 CREATE TABLE #codessnomed (
@@ -119,7 +120,7 @@ INSERT INTO #codessnomed
 VALUES ('hba1c',1,'1019431000000105','HbA1c level (Diabetes Control and Complications Trial aligned)'),('hba1c',1,'1003671000000109','Haemoglobin A1c level'),('hba1c',1,'1049301000000100','HbA1c (haemoglobin A1c) level (diagnostic reference range) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'1049321000000109','HbA1c (haemoglobin A1c) level (monitoring ranges) - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'1107481000000106','HbA1c (haemoglobin A1c) molar concentration in blood'),('hba1c',1,'999791000000106','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised'),('hba1c',1,'1010941000000103','Haemoglobin A1c (monitoring ranges)'),('hba1c',1,'1010951000000100','Haemoglobin A1c (diagnostic reference range)'),('hba1c',1,'165679005','Haemoglobin A1c (HbA1c) less than 7% indicating good diabetic control'),('hba1c',1,'165680008','Haemoglobin A1c (HbA1c) between 7%-10% indicating borderline diabetic control'),('hba1c',1,'165681007','Hemoglobin A1c (HbA1c) greater than 10% indicating poor diabetic control'),('hba1c',1,'365845005','Haemoglobin A1C - diabetic control finding'),('hba1c',1,'444751005','High hemoglobin A1c level'),('hba1c',1,'43396009','Hemoglobin A1c measurement (procedure)'),('hba1c',1,'313835008','Hemoglobin A1c measurement aligned to the Diabetes Control and Complications Trial'),('hba1c',1,'371981000000106','Hb A1c (Haemoglobin A1c) level - IFCC (International Federation of Clinical Chemistry and Laboratory Medicine) standardised'),('hba1c',1,'444257008','Calculation of estimated average glucose based on haemoglobin A1c'),('hba1c',1,'269823000','Haemoglobin A1C - diabetic control interpretation'),('hba1c',1,'443911005','Ordinal level of hemoglobin A1c'),('hba1c',1,'733830002','HbA1c - Glycated haemoglobin-A1c'),('hba1c',2,'1019431000000105','HbA1c level (Diabetes Control and Complications Trial aligned)'),('hba1c',2,'999791000000106','Haemoglobin A1c level - International Federation of Clinical Chemistry and Laboratory Medicine standardised')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codessnomed;
+SELECT [concept], [version], [code], [description] from #codessnomed;
 
 IF OBJECT_ID('tempdb..#codesemis') IS NOT NULL DROP TABLE #codesemis;
 CREATE TABLE #codesemis (
@@ -133,15 +134,15 @@ INSERT INTO #codesemis
 VALUES ('bmi',1,'EMISNQBM1','BMI centile')
 
 INSERT INTO #AllCodes
-SELECT [concept], [version], [code] from #codesemis;
+SELECT [concept], [version], [code], [description] from #codesemis;
 
 
 IF OBJECT_ID('tempdb..#TempRefCodes') IS NOT NULL DROP TABLE #TempRefCodes;
-CREATE TABLE #TempRefCodes (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, version INT NOT NULL);
+CREATE TABLE #TempRefCodes (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, version INT NOT NULL, [description] VARCHAR(255));
 
 -- Read v2 codes
 INSERT INTO #TempRefCodes
-SELECT PK_Reference_Coding_ID, dcr.concept, dcr.[version]
+SELECT PK_Reference_Coding_ID, dcr.concept, dcr.[version], dcr.[description]
 FROM [SharedCare].[Reference_Coding] rc
 INNER JOIN #codesreadv2 dcr on dcr.code = rc.MainCode
 WHERE CodingType='ReadCodeV2'
@@ -149,7 +150,7 @@ and PK_Reference_Coding_ID != -1;
 
 -- CTV3 codes
 INSERT INTO #TempRefCodes
-SELECT PK_Reference_Coding_ID, dcc.concept, dcc.[version]
+SELECT PK_Reference_Coding_ID, dcc.concept, dcc.[version], dcc.[description]
 FROM [SharedCare].[Reference_Coding] rc
 INNER JOIN #codesctv3 dcc on dcc.code = rc.MainCode
 WHERE CodingType='CTV3'
@@ -157,23 +158,23 @@ and PK_Reference_Coding_ID != -1;
 
 -- EMIS codes with a FK Reference Coding ID
 INSERT INTO #TempRefCodes
-SELECT FK_Reference_Coding_ID, ce.concept, ce.[version]
+SELECT FK_Reference_Coding_ID, ce.concept, ce.[version], ce.[description]
 FROM [SharedCare].[Reference_Local_Code] rlc
 INNER JOIN #codesemis ce on ce.code = rlc.LocalCode
 WHERE FK_Reference_Coding_ID != -1;
 
 IF OBJECT_ID('tempdb..#TempSNOMEDRefCodes') IS NOT NULL DROP TABLE #TempSNOMEDRefCodes;
-CREATE TABLE #TempSNOMEDRefCodes (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [version] INT NOT NULL);
+CREATE TABLE #TempSNOMEDRefCodes (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [version] INT NOT NULL, [description] VARCHAR(255));
 
 -- SNOMED codes
 INSERT INTO #TempSNOMEDRefCodes
-SELECT PK_Reference_SnomedCT_ID, dcs.concept, dcs.[version]
+SELECT PK_Reference_SnomedCT_ID, dcs.concept, dcs.[version], dcs.[description]
 FROM SharedCare.Reference_SnomedCT rs
 INNER JOIN #codessnomed dcs on dcs.code = rs.ConceptID;
 
 -- EMIS codes with a FK SNOMED ID but without a FK Reference Coding ID
 INSERT INTO #TempSNOMEDRefCodes
-SELECT FK_Reference_SnomedCT_ID, ce.concept, ce.[version]
+SELECT FK_Reference_SnomedCT_ID, ce.concept, ce.[version], ce.[description]
 FROM [SharedCare].[Reference_Local_Code] rlc
 INNER JOIN #codesemis ce on ce.code = rlc.LocalCode
 WHERE FK_Reference_Coding_ID = -1
@@ -181,16 +182,16 @@ AND FK_Reference_SnomedCT_ID != -1;
 
 -- De-duped tables
 IF OBJECT_ID('tempdb..#CodeSets') IS NOT NULL DROP TABLE #CodeSets;
-CREATE TABLE #CodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL);
+CREATE TABLE #CodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#SnomedSets') IS NOT NULL DROP TABLE #SnomedSets;
-CREATE TABLE #SnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL);
+CREATE TABLE #SnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, concept VARCHAR(255) NOT NULL, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#VersionedCodeSets') IS NOT NULL DROP TABLE #VersionedCodeSets;
-CREATE TABLE #VersionedCodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT);
+CREATE TABLE #VersionedCodeSets (FK_Reference_Coding_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT, [description] VARCHAR(255));
 
 IF OBJECT_ID('tempdb..#VersionedSnomedSets') IS NOT NULL DROP TABLE #VersionedSnomedSets;
-CREATE TABLE #VersionedSnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT);
+CREATE TABLE #VersionedSnomedSets (FK_Reference_SnomedCT_ID BIGINT NOT NULL, Concept VARCHAR(255), [Version] INT, [description] VARCHAR(255));
 
 INSERT INTO #VersionedCodeSets
 SELECT DISTINCT * FROM #TempRefCodes;
@@ -199,7 +200,7 @@ INSERT INTO #VersionedSnomedSets
 SELECT DISTINCT * FROM #TempSNOMEDRefCodes;
 
 INSERT INTO #CodeSets
-SELECT FK_Reference_Coding_ID, c.concept
+SELECT FK_Reference_Coding_ID, c.concept, [description]
 FROM #VersionedCodeSets c
 INNER JOIN (
   SELECT concept, MAX(version) AS maxVersion FROM #VersionedCodeSets
@@ -207,7 +208,7 @@ INNER JOIN (
 sub ON sub.concept = c.concept AND c.version = sub.maxVersion;
 
 INSERT INTO #SnomedSets
-SELECT FK_Reference_SnomedCT_ID, c.concept
+SELECT FK_Reference_SnomedCT_ID, c.concept, [description]
 FROM #VersionedSnomedSets c
 INNER JOIN (
   SELECT concept, MAX(version) AS maxVersion FROM #VersionedSnomedSets

--- a/projects/001 - Grant/extraction-sql/secondary-utilisation-file-1.sql
+++ b/projects/001 - Grant/extraction-sql/secondary-utilisation-file-1.sql
@@ -1106,7 +1106,7 @@ ORDER BY a.FK_Patient_Link_ID, a.AdmissionDate, a.AcuteProvider;
 -- INPUT: Takes one parameter
 --  - start-date: string - (YYYY-MM-DD) the date to count diagnoses from. Usually this should be 2020-01-01.
 
--- OUTPUT: Two temp table as follows:
+-- OUTPUT: Two temp tables as follows:
 -- #CovidPatients (FK_Patient_Link_ID, FirstCovidPositiveDate)
 -- 	- FK_Patient_Link_ID - unique patient id
 --	- FirstCovidPositiveDate - earliest COVID diagnosis

--- a/projects/001 - Grant/extraction-sql/secondary-utilisation-file-2.sql
+++ b/projects/001 - Grant/extraction-sql/secondary-utilisation-file-2.sql
@@ -1117,7 +1117,7 @@ ORDER BY a.FK_Patient_Link_ID, a.AdmissionDate, a.AcuteProvider;
 -- INPUT: Takes one parameter
 --  - start-date: string - (YYYY-MM-DD) the date to count diagnoses from. Usually this should be 2020-01-01.
 
--- OUTPUT: Two temp table as follows:
+-- OUTPUT: Two temp tables as follows:
 -- #CovidPatients (FK_Patient_Link_ID, FirstCovidPositiveDate)
 -- 	- FK_Patient_Link_ID - unique patient id
 --	- FirstCovidPositiveDate - earliest COVID diagnosis

--- a/projects/001 - Grant/template-sql/primary-utilisation-file-4.template.sql
+++ b/projects/001 - Grant/template-sql/primary-utilisation-file-4.template.sql
@@ -38,10 +38,24 @@ SELECT DISTINCT FK_Patient_Link_ID, FirstMedDate as EventDate INTO #PatientDates
 
 --> EXECUTE query-patient-practice-and-ccg.sql
 
+-- We need to remove the main COVID vaccine codes from the medications as they cause
+-- spikes which we're not interested in
+IF OBJECT_ID('tempdb..#COVIDVaccMedCodes') IS NOT NULL DROP TABLE #COVIDVaccMedCodes;
+SELECT 'S'+CONVERT(VARCHAR,FK_Reference_SnomedCT_ID) AS Code INTO #COVIDVaccMedCodes
+FROM SharedCare.Reference_Local_Code
+WHERE LocalCode IN ('COCO138186NEMIS','CODI138564NEMIS','TASO138184NEMIS')
+AND FK_Reference_SnomedCT_ID != -1
+UNION
+SELECT 'F'+CONVERT(VARCHAR,FK_Reference_Coding_ID) FROM SharedCare.Reference_Local_Code
+WHERE LocalCode IN ('COCO138186NEMIS','CODI138564NEMIS','TASO138184NEMIS')
+AND FK_Reference_Coding_ID != -1;
+
 -- Bring it all together for output
 -- PRINT 'FirstMedDate,CCG,GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived,LTCGroup,CovidHealthcareUtilisation,NumberFirstPrescriptions';
 SELECT 
-	fm.FirstMedDate, CCG, GPPracticeCode, 
+	fm.FirstMedDate,	
+	'Y' AS IsCovidVaccine,
+	CCG, GPPracticeCode, 
 	ISNULL(IMD2019Decile1IsMostDeprived10IsLeastDeprived, 0) AS IMD2019Decile1IsMostDeprived10IsLeastDeprived, 
 	ISNULL(LTCGroup, 'None') AS LTCGroup, CovidHealthcareUtilisation, count(*) AS NumberFirstPrescriptions  
 FROM #FirstMedications fm
@@ -49,5 +63,20 @@ LEFT OUTER JOIN #COVIDUtilisationPrimaryCare c ON c.FK_Patient_Link_ID = fm.FK_P
 LEFT OUTER JOIN #LTCGroups ltc ON ltc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientIMDDecile imd ON imd.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientPracticeAndCCG pc ON pc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+WHERE fm.Code IN (SELECT Code FROM #COVIDVaccMedCodes)
 GROUP BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, LTCGroup, CovidHealthcareUtilisation
-ORDER BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, LTCGroup, CovidHealthcareUtilisation;
+UNION
+SELECT 
+	fm.FirstMedDate,	
+	'N' AS IsCovidVaccine,
+	CCG, GPPracticeCode, 
+	ISNULL(IMD2019Decile1IsMostDeprived10IsLeastDeprived, 0) AS IMD2019Decile1IsMostDeprived10IsLeastDeprived, 
+	ISNULL(LTCGroup, 'None') AS LTCGroup, CovidHealthcareUtilisation, count(*) AS NumberFirstPrescriptions  
+FROM #FirstMedications fm
+LEFT OUTER JOIN #COVIDUtilisationPrimaryCare c ON c.FK_Patient_Link_ID = fm.FK_Patient_Link_ID AND c.EventDate = fm.FirstMedDate
+LEFT OUTER JOIN #LTCGroups ltc ON ltc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientIMDDecile imd ON imd.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientPracticeAndCCG pc ON pc.FK_Patient_Link_ID = fm.FK_Patient_Link_ID
+WHERE fm.Code NOT IN (SELECT Code FROM #COVIDVaccMedCodes)
+GROUP BY FirstMedDate, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, LTCGroup, CovidHealthcareUtilisation
+ORDER BY FirstMedDate, IsCovidVaccine, CCG, GPPracticeCode,IMD2019Decile1IsMostDeprived10IsLeastDeprived, LTCGroup, CovidHealthcareUtilisation;


### PR DESCRIPTION
The 1st Rx of meds to assess healthcare utilisation currently sees a large spike in Jan 2021 onwards. This is because sometimes the covid vaccination product is recorded in the patients' record. This change helps distinguish between the codes that are covid vaccinations and all other meds.