### PR TITLE
Fix SecondVaccine issue

### DIFF
--- a/projects/028 - Firth (Hassan)/template-sql/patients.template.sql
+++ b/projects/028 - Firth (Hassan)/template-sql/patients.template.sql
@@ -73,6 +73,7 @@ SELECT
 	,SecondVaccineDate = VaccineDose2Date 
 INTO #COVIDVaccinations1
 FROM #COVIDVaccinations
+WHERE
 	(VaccineDose1Date <= @EndDate OR VaccineDose1Date IS NULL) AND 
 	(VaccineDose2Date <= @EndDate OR VaccineDose2Date IS NULL)
 -- Get patients with covid vaccine refusal

--- a/projects/028 - Firth (Hassan)/template-sql/patients.template.sql
+++ b/projects/028 - Firth (Hassan)/template-sql/patients.template.sql
@@ -73,8 +73,8 @@ SELECT
 	,SecondVaccineDate = VaccineDose2Date 
 INTO #COVIDVaccinations1
 FROM #COVIDVaccinations
-WHERE VaccineDose1Date <= @EndDate AND VaccineDose2Date <= @EndDate
-
+	(VaccineDose1Date <= @EndDate OR VaccineDose1Date IS NULL) AND 
+	(VaccineDose2Date <= @EndDate OR VaccineDose2Date IS NULL)
 -- Get patients with covid vaccine refusal
 
 --> CODESET covid-vaccine-declined:1


### PR DESCRIPTION
In the data extract, the number of NULL values for Vaccine1Date and Vaccine2Date were exactly the same. I have fixed the code to allow nulls in SecondVaccineDate and this has solved the issue. There are now some patients with a first vaccine but not a second, which makes sense.