### PR TITLE
Actually need nhs no not link id

### DIFF
--- a/projects/019 - Heald DARE/template-sql/bio-markers.template.sql
+++ b/projects/019 - Heald DARE/template-sql/bio-markers.template.sql
@@ -30,6 +30,11 @@ SELECT DISTINCT FK_Patient_Link_ID INTO #Patients
 FROM [RLS].vw_Patient p
 INNER JOIN #DAREPatients dp ON dp.NhsNo = p.NhsNo;
 
+-- Get lookup between nhs number and fk_patient_link_id
+SELECT DISTINCT p.NhsNo, p.FK_Patient_Link_ID INTO #NhsNoToLinkId
+FROM [RLS].vw_Patient p
+INNER JOIN #DAREPatients dp ON dp.NhsNo = p.NhsNo;
+
 --> CODESET bmi:2 hba1c:2 cholesterol:2 ldl-cholesterol:1 hdl-cholesterol:1 vitamin-d:1 testosterone:1 sex-hormone-binding-globulin:1 egfr:1
 
 -- First lets get all the measurements in one place to improve query speed later on
@@ -134,5 +139,6 @@ WHERE (
 );
 
 -- Final output
-SELECT FK_Patient_Link_ID AS PatientId, Label, EventDate, [Value] FROM #biomarkers
+SELECT NhsNo, Label, EventDate, [Value] FROM #biomarkers b
+INNER JOIN #NhsNoToLinkId n on n.FK_Patient_Link_ID = b.FK_Patient_Link_ID
 ORDER BY FK_Patient_Link_ID, EventDate;

--- a/projects/019 - Heald DARE/template-sql/cohort.template.sql
+++ b/projects/019 - Heald DARE/template-sql/cohort.template.sql
@@ -51,6 +51,11 @@ SELECT p.FK_Patient_Link_ID INTO #Patients
 FROM [RLS].vw_Patient p
 INNER JOIN #DAREPatients dp ON dp.NhsNo = p.NhsNo;
 
+-- Get lookup between nhs number and fk_patient_link_id
+SELECT DISTINCT p.NhsNo, p.FK_Patient_Link_ID INTO #NhsNoToLinkId
+FROM [RLS].vw_Patient p
+INNER JOIN #DAREPatients dp ON dp.NhsNo = p.NhsNo;
+
 --Below is for testing without access to DARE nhs numbers
 --IF OBJECT_ID('tempdb..#Patients') IS NOT NULL DROP TABLE #Patients;
 --SELECT TOP 200 FK_Patient_Link_ID INTO #Patients
@@ -374,7 +379,7 @@ AND FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients);
 
 -- Bring together for final output
 SELECT 
-  m.FK_Patient_Link_ID AS PatientId,
+  NhsNo,
   YearOfBirth,
   DeathDate,
   CASE WHEN covidDeath.FK_Patient_Link_ID IS NULL THEN 'N' ELSE 'Y' END AS DeathWithin28DaysCovidPositiveTest,
@@ -420,6 +425,7 @@ SELECT
   IsOnGLP1A,
   IsOnSulphonylurea
 FROM #Patients m
+INNER JOIN #NhsNoToLinkId n on n.FK_Patient_Link_ID = m.FK_Patient_Link_ID
 LEFT OUTER JOIN RLS.vw_Patient_Link pl ON pl.PK_Patient_Link_ID = m.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientLSOA lsoa ON lsoa.FK_Patient_Link_ID = m.FK_Patient_Link_ID
 LEFT OUTER JOIN #PatientSex sex ON sex.FK_Patient_Link_ID = m.FK_Patient_Link_ID


### PR DESCRIPTION
Further to previous PR, I've realised that for the linkage to take place on the VDE it's actually the nhs number rather than the patient_link_id that is required for this extract.