### PR TITLE
Update rq034 allergy scripts

### DIFF
--- a/projects/034 - Williams/extraction-sql/09NewAllergies.sql
+++ b/projects/034 - Williams/extraction-sql/09NewAllergies.sql
@@ -276,7 +276,112 @@ sub ON sub.concept = c.concept AND c.version = sub.maxVersion;
 --#endregion
 
 -- >>> Following code sets injected: allergy v1
+--┌───────────────────────────────────────┐
+--│ GET practice and ccg for each patient │
+--└───────────────────────────────────────┘
 
+-- OBJECTIVE:	For each patient to get the practice id that they are registered to, and 
+--						the CCG name that the practice belongs to.
+
+-- INPUT: Assumes there exists a temp table as follows:
+-- #Patients (FK_Patient_Link_ID)
+--  A distinct list of FK_Patient_Link_IDs for each patient in the cohort
+
+-- OUTPUT: Two temp tables as follows:
+-- #PatientPractice (FK_Patient_Link_ID, GPPracticeCode)
+--	- FK_Patient_Link_ID - unique patient id
+--	- GPPracticeCode - the nationally recognised practice id for the patient
+-- #PatientPracticeAndCCG (FK_Patient_Link_ID, GPPracticeCode, CCG)
+--	- FK_Patient_Link_ID - unique patient id
+--	- GPPracticeCode - the nationally recognised practice id for the patient
+--	- CCG - the name of the patient's CCG
+
+-- If patients have a tenancy id of 2 we take this as their most likely GP practice
+-- as this is the GP data feed and so most likely to be up to date
+IF OBJECT_ID('tempdb..#PatientPractice') IS NOT NULL DROP TABLE #PatientPractice;
+SELECT FK_Patient_Link_ID, MIN(GPPracticeCode) as GPPracticeCode INTO #PatientPractice FROM SharedCare.Patient
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND FK_Reference_Tenancy_ID = 2
+AND GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID;
+-- 1298467 rows
+-- 00:00:11
+
+-- Find the patients who remain unmatched
+IF OBJECT_ID('tempdb..#UnmatchedPatientsForPracticeCode') IS NOT NULL DROP TABLE #UnmatchedPatientsForPracticeCode;
+SELECT FK_Patient_Link_ID INTO #UnmatchedPatientsForPracticeCode FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientPractice;
+-- 12702 rows
+-- 00:00:00
+
+-- If every GPPracticeCode is the same for all their linked patient ids then we use that
+INSERT INTO #PatientPractice
+SELECT FK_Patient_Link_ID, MIN(GPPracticeCode) FROM SharedCare.Patient
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedPatientsForPracticeCode)
+AND GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(GPPracticeCode) = MAX(GPPracticeCode);
+-- 12141
+-- 00:00:00
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedPatientsForPracticeCode;
+INSERT INTO #UnmatchedPatientsForPracticeCode
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientPractice;
+-- 561 rows
+-- 00:00:00
+
+-- If there is a unique most recent gp practice then we use that
+INSERT INTO #PatientPractice
+SELECT p.FK_Patient_Link_ID, MIN(p.GPPracticeCode) FROM SharedCare.Patient p
+INNER JOIN (
+	SELECT FK_Patient_Link_ID, MAX(HDMModifDate) MostRecentDate FROM SharedCare.Patient
+	WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedPatientsForPracticeCode)
+	GROUP BY FK_Patient_Link_ID
+) sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.MostRecentDate = p.HDMModifDate
+WHERE p.GPPracticeCode IS NOT NULL
+GROUP BY p.FK_Patient_Link_ID
+HAVING MIN(GPPracticeCode) = MAX(GPPracticeCode);
+-- 15
+
+--┌──────────────────┐
+--│ CCG lookup table │
+--└──────────────────┘
+
+-- OBJECTIVE: To provide lookup table for CCG names. The GMCR provides the CCG id (e.g. '00T', '01G') but not 
+--            the CCG name. This table can be used in other queries when the output is required to be a ccg 
+--            name rather than an id.
+
+-- INPUT: No pre-requisites
+
+-- OUTPUT: A temp table as follows:
+-- #CCGLookup (CcgId, CcgName)
+-- 	- CcgId - Nationally recognised ccg id
+--	- CcgName - Bolton, Stockport etc..
+
+IF OBJECT_ID('tempdb..#CCGLookup') IS NOT NULL DROP TABLE #CCGLookup;
+CREATE TABLE #CCGLookup (CcgId nchar(3), CcgName nvarchar(20));
+INSERT INTO #CCGLookup VALUES ('01G', 'Salford'); 
+INSERT INTO #CCGLookup VALUES ('00T', 'Bolton'); 
+INSERT INTO #CCGLookup VALUES ('01D', 'HMR'); 
+INSERT INTO #CCGLookup VALUES ('02A', 'Trafford'); 
+INSERT INTO #CCGLookup VALUES ('01W', 'Stockport');
+INSERT INTO #CCGLookup VALUES ('00Y', 'Oldham'); 
+INSERT INTO #CCGLookup VALUES ('02H', 'Wigan'); 
+INSERT INTO #CCGLookup VALUES ('00V', 'Bury'); 
+INSERT INTO #CCGLookup VALUES ('14L', 'Manchester'); 
+INSERT INTO #CCGLookup VALUES ('01Y', 'Tameside Glossop'); 
+
+IF OBJECT_ID('tempdb..#PatientPracticeAndCCG') IS NOT NULL DROP TABLE #PatientPracticeAndCCG;
+SELECT p.FK_Patient_Link_ID, ISNULL(pp.GPPracticeCode,'') AS GPPracticeCode, ISNULL(ccg.CcgName, '') AS CCG
+INTO #PatientPracticeAndCCG
+FROM #Patients p
+LEFT OUTER JOIN #PatientPractice pp ON pp.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN SharedCare.Reference_GP_Practice gp ON gp.OrganisationCode = pp.GPPracticeCode
+LEFT OUTER JOIN #CCGLookup ccg ON ccg.CcgId = gp.Commissioner;
 
 -- Delete code H171. in #AllCodes table==================================================================================================================================
 -- This will delete 5 codes: Cat allergy, Dander (animal) allergy, House dust allergy, Feather allergy, House dust mite allergy
@@ -284,9 +389,10 @@ DELETE FROM #AllCodes WHERE Code = 'H171.'
 
 -- Create a table of all patients with GP events after the start date========================================================================================================
 IF OBJECT_ID('tempdb..#AllergyAll') IS NOT NULL DROP TABLE #AllergyAll;
-SELECT DISTINCT FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, SuppliedCode, GPPracticeCode
+SELECT DISTINCT p.FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, SuppliedCode, gp.GPPracticeCode
 INTO #AllergyAll
-FROM SharedCare.GP_Events
+FROM SharedCare.GP_Events p
+LEFT OUTER JOIN #PatientPractice gp ON p.FK_Patient_Link_ID = gp.FK_Patient_Link_ID
 WHERE (SuppliedCode IN (SELECT Code FROM #AllCodes WHERE (Concept = 'allergy' AND [Version] = 1)))
       AND EventDate < @EndDate;
 

--- a/projects/034 - Williams/template-sql/09NewAllergies.template.sql
+++ b/projects/034 - Williams/template-sql/09NewAllergies.template.sql
@@ -31,7 +31,7 @@ INTO #Patients
 FROM #PatientsToInclude;
 
 --> CODESET allergy:1
-
+--> EXECUTE query-patient-practice-and-ccg.sql
 
 -- Delete code H171. in #AllCodes table==================================================================================================================================
 -- This will delete 5 codes: Cat allergy, Dander (animal) allergy, House dust allergy, Feather allergy, House dust mite allergy
@@ -39,9 +39,10 @@ DELETE FROM #AllCodes WHERE Code = 'H171.'
 
 -- Create a table of all patients with GP events after the start date========================================================================================================
 IF OBJECT_ID('tempdb..#AllergyAll') IS NOT NULL DROP TABLE #AllergyAll;
-SELECT DISTINCT FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, SuppliedCode, GPPracticeCode
+SELECT DISTINCT p.FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, SuppliedCode, gp.GPPracticeCode
 INTO #AllergyAll
-FROM SharedCare.GP_Events
+FROM SharedCare.GP_Events p
+LEFT OUTER JOIN #PatientPractice gp ON p.FK_Patient_Link_ID = gp.FK_Patient_Link_ID
 WHERE (SuppliedCode IN (SELECT Code FROM #AllCodes WHERE (Concept = 'allergy' AND [Version] = 1)))
       AND EventDate < @EndDate;
 

--- a/projects/034 - Williams/template-sql/09NewAllergies.template.sql
+++ b/projects/034 - Williams/template-sql/09NewAllergies.template.sql
@@ -33,9 +33,13 @@ FROM #PatientsToInclude;
 --> CODESET allergy:1
 
 
+-- Delete code H171. in #AllCodes table==================================================================================================================================
+-- This will delete 5 codes: Cat allergy, Dander (animal) allergy, House dust allergy, Feather allergy, House dust mite allergy
+DELETE FROM #AllCodes WHERE Code = 'H171.'
+
 -- Create a table of all patients with GP events after the start date========================================================================================================
 IF OBJECT_ID('tempdb..#AllergyAll') IS NOT NULL DROP TABLE #AllergyAll;
-SELECT DISTINCT FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, FK_Reference_Coding_ID, GPPracticeCode
+SELECT DISTINCT FK_Patient_Link_ID, TRY_CONVERT(DATE, EventDate) AS EventDate, SuppliedCode, GPPracticeCode
 INTO #AllergyAll
 FROM SharedCare.GP_Events
 WHERE (SuppliedCode IN (SELECT Code FROM #AllCodes WHERE (Concept = 'allergy' AND [Version] = 1)))
@@ -43,13 +47,13 @@ WHERE (SuppliedCode IN (SELECT Code FROM #AllCodes WHERE (Concept = 'allergy' AN
 
 
 -- Found 2 codes with strange strikes in practice P87002. Exclude these codes in this practice==================================================================
-DELETE FROM #AllergyAll WHERE (GPPracticeCode = 'P87002' AND FK_Reference_Coding_ID = 607002) 
-                              OR (GPPracticeCode = 'P87002' AND FK_Reference_Coding_ID = 607018)
+DELETE FROM #AllergyAll WHERE (GPPracticeCode = 'P87002' AND SuppliedCode = 'TJC24') 
+                              OR (GPPracticeCode = 'P87002' AND SuppliedCode = 'TJC47')
 
 
 -- Create the table of new allergy code=============================================================================================================
 SELECT FK_Patient_Link_ID AS PatientId, MIN(EventDate) AS Date
 FROM #AllergyAll
 WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #PatientsToInclude)
-GROUP BY FK_Patient_Link_ID, FK_Reference_Coding_ID
+GROUP BY FK_Patient_Link_ID, SuppliedCode
 HAVING YEAR(MIN(EventDate)) >= 2019;


### PR DESCRIPTION
Thanks Richard for spotting that. I realised I used SuppliedCode in the AllCodes table in the past but recently investigated with FK_Reference_Coding_ID in the VersionedCodeSets table (oops).

I think a while ago we looked at allergy codes and decided that SuppliedCode in the AllCode table will be a better choice to select allergy codes. Therefore, I edited the script based on SuppliedCode. When you do the graph again, please let me know about the strikes.

Changes:
- Use GPPracticeCode from query-patient-practice-and-ccg.sql instead of SharedCare.GP_Events
- Delete code H171. from #AllCode table
- Delete SuppliedCode = 'TJC24' or SuppliedCode = 'TJC47' for GPPracticeCode P87002.