### PR TITLE
Long covid

### DIFF
--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/README.md
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/README.md
@@ -1,0 +1,13 @@
+# Long COVID diagnosis
+
+Any code indicating a diagnosis of long-covid / post-covid syndrome. There are also code sets for [long-covid-assessment](../../../patient/long-covid-assessment/) and [long-covid-referral](../../../patient/long-covid-referral/).
+
+## Prevalence log
+
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.095% - 0.401%` suggests missing codes from TPP practices. However, there is literature showing that all long covid codes are poorly used (https://doi.org/10.3399%2FBJGP.2021.0301 and https://www.adruk.org/fileadmin/uploads/adruk/Documents/Data_Insights/Clinical_coding_and_capture_of_Long_COVID_V.3__4_.pdf).
+
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------: | ----------------: |
+| 2023-09-12 | EMIS            | 2463856    |    9874 (0.401%) |     9879 (0.401%) |
+| 2023-09-12 | TPP             | 200590     |      26 (0.013%) |     191 (0.0952%) |
+| 2023-09-12 | Vision          | 332095     |     808 (0.243%) |      810 (0.244%) |

--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.ctv3.txt
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.ctv3.txt
@@ -1,0 +1,2 @@
+Y2b87	Post-COVID-19 syndrome
+Y2a15	Current ongoing illness following confirmed SARS-CoV-2 infection

--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.emis.txt
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.emis.txt
@@ -1,2 +1,5 @@
 ^ESCT1348645	Post-COVID-19 syndrome
 ^ESCT1348648	Ongoing symptomatic COVID-19
+^ESCT1348649	Ongoing symptomatic disease caused by severe acute respiratory syndrome coronavirus 2
+^ESCT1416863	Chronic post-COVID-19 syndrome
+^ESCT1416864	Chronic COVID-19 syndrome

--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.emis.txt
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.emis.txt
@@ -1,0 +1,2 @@
+^ESCT1348645	Post-COVID-19 syndrome
+^ESCT1348648	Ongoing symptomatic COVID-19

--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.readv2.txt
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.readv2.txt
@@ -1,0 +1,2 @@
+A795500	Ongoing symptomatic COVID-19
+AyuJC00	Post-COVID-19 syndrome

--- a/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.snomed.txt
+++ b/shared/clinical-code-sets/conditions/long-covid-diagnosis/1/long-covid-diagnosis.snomed.txt
@@ -1,0 +1,3 @@
+1325161000000102	Post-COVID-19 syndrome
+1325181000000106	Ongoing symptomatic disease caused by severe acute respiratory syndrome coronavirus 2
+1119304009	Chronic post-COVID-19 syndrome

--- a/shared/clinical-code-sets/conditions/long-covid/1/README.md
+++ b/shared/clinical-code-sets/conditions/long-covid/1/README.md
@@ -1,14 +1,15 @@
 # long covid
 
-Any code indicating presence of long covid
+Any code indicating presence of long covid.
+
+_NB this code set contains a mixture of diagnosis, assessment and referral codes. Please refer to the separate code sets for [long-covid-diagnosis](../../long-covid-diagnosis/), [long-covid-assessment](../../../patient/long-covid-assessment/), and [long-covid-referral](../../../patient/long-covid-referral/) if granularity is required_
 
 ## Prevalence log
 
 By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.55% - 13.96%` suggests missing codes from Vision and TPP practices.
 
-
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2021-03-11 | EMIS            | 2600658    |  371790 (13.96%) |    20088 (0.75%)  |
-| 2021-03-11 | TPP             | 210333     |     1179 (0.55%) |      141 (0.07%)  |
-| 2021-03-11 | Vision          | 333251     |     4084 (1.19%) |      676 (0.20%)  |
+| 2021-03-11 | EMIS            | 2600658    |  371790 (13.96%) |     20088 (0.75%) |
+| 2021-03-11 | TPP             | 210333     |     1179 (0.55%) |       141 (0.07%) |
+| 2021-03-11 | Vision          | 333251     |     4084 (1.19%) |       676 (0.20%) |

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/README.md
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/README.md
@@ -1,0 +1,13 @@
+# Long COVID assessment
+
+Any code indicating an assessment of long-covid / post-covid syndrome. There are also code sets for [long-covid-diagnosis](../../../conditions/long-covid-diagnosis/) and [long-covid-referral](../../long-covid-referral/).
+
+## Prevalence log
+
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.0% - 0.007%` suggests missing codes from all practices. However, there is literature showing that all long covid codes are poorly used (https://doi.org/10.3399%2FBJGP.2021.0301 and https://www.adruk.org/fileadmin/uploads/adruk/Documents/Data_Insights/Clinical_coding_and_capture_of_Long_COVID_V.3__4_.pdf). So this is probably lack of use rather than missing codes.
+
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------: | ----------------: |
+| 2023-09-12 | EMIS            | 2463856    |   166 (0.00674%) |    166 (0.00674%) |
+| 2023-09-12 | TPP             | 200590     |           0 (0%) |            0 (0%) |
+| 2023-09-12 | Vision          | 332095     |    1 (0.000301%) |     1 (0.000301%) |

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.ctv3.txt
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.ctv3.txt
@@ -1,0 +1,1 @@
+Y2b8c	Assessment using COVID-19 Yorkshire Rehabilitation Screening tool

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.emis.txt
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.emis.txt
@@ -8,3 +8,11 @@
 ^ESCT1348639	PCFS (Post-COVID-19 Functional Status) Scale structured interview nal scale grade
 ^ESCT1348641	Assessment using PCFS (Post-COVID-19 Functional Status) Scale structured interview
 ^ESCT1348643	PCFS (Post-COVID-19 Functional Status) Scale structured interview
+^ESCT1348630	COVID-19 Yorkshire Rehabilitation Screening tool
+^ESCT1348632	Assessment using COVID-19 Yorkshire Rehabilitation Screening tool
+^ESCT1348634	Post-COVID-19 Functional Status Scale patient self-report
+^ESCT1348636	Assessment using Post-COVID-19 Functional Status Scale patient self-report
+^ESCT1348638	Post-COVID-19 Functional Status Scale patient self-report final scale grade
+^ESCT1348640	Post-COVID-19 Functional Status Scale structured interview final scale grade
+^ESCT1348642	Assessment using Post-COVID-19 Functional Status Scale structured interview
+^ESCT1348644	Post-COVID-19 Functional Status Scale structured interview

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.emis.txt
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.emis.txt
@@ -1,0 +1,10 @@
+^ESCT1348628	Assessment using Newcastle post-COVID syndrome Follow-up Screening Questionnaire
+^ESCT1348627	Newcastle post-COVID syndrome Follow-up Screening Questionnaire
+^ESCT1348631	Assessment using C19-YRS (COVID-19 Yorkshire Rehabilitation Screening) tool
+^ESCT1348633	PCFS (Post-COVID-19 Functional Status) Scale patient self-report
+^ESCT1348629	C19-YRS (COVID-19 Yorkshire Rehabilitation Screening) tool
+^ESCT1348635	Assessment using PCFS (Post-COVID-19 Functional Status) Scale patient self-report
+^ESCT1348637	PCFS (Post-COVID-19 Functional Status) Scale patient self-report nal scale grade
+^ESCT1348639	PCFS (Post-COVID-19 Functional Status) Scale structured interview nal scale grade
+^ESCT1348641	Assessment using PCFS (Post-COVID-19 Functional Status) Scale structured interview
+^ESCT1348643	PCFS (Post-COVID-19 Functional Status) Scale structured interview

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.readv2.txt
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.readv2.txt
@@ -1,0 +1,2 @@
+38Vx.00	Post-COVID-19 Functional Status Scale patient self-report final scale grade 
+38Vy.00	Post-COVID-19 Functional Status Scale structured interview final scale grade 

--- a/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.snomed.txt
+++ b/shared/clinical-code-sets/patient/long-covid-assessment/1/long-covid-assessment.snomed.txt
@@ -1,0 +1,10 @@
+1325051000000101	Newcastle post-COVID syndrome Follow-up Screening Questionnaire
+1325061000000103	Assessment using Newcastle post-COVID syndrome Follow-up Screening Questionnaire
+1325071000000105	COVID-19 Yorkshire Rehabilitation Screening tool
+1325081000000107	Assessment using COVID-19 Yorkshire Rehabilitation Screening tool
+1325091000000109	Post-COVID-19 Functional Status Scale patient self-report
+1325101000000101	Assessment using Post-COVID-19 Functional Status Scale patient self-report
+1325121000000105	Post-COVID-19 Functional Status Scale patient self-report final scale grade
+1325131000000107	Post-COVID-19 Functional Status Scale structured interview final scale grade
+1325141000000103	Assessment using Post-COVID-19 Functional Status Scale structured interview
+1325151000000100	Post-COVID-19 Functional Status Scale structured interview

--- a/shared/clinical-code-sets/patient/long-covid-referral/1/README.md
+++ b/shared/clinical-code-sets/patient/long-covid-referral/1/README.md
@@ -1,0 +1,13 @@
+# Long COVID referral
+
+Any code indicating a referral for long-covid / post-covid syndrome. There are also code sets for [long-covid-diagnosis](../../../conditions/long-covid-diagnosis/) and [long-covid-assessment](../../long-covid-assessment/).
+
+## Prevalence log
+
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.15% - 0.657%` suggests missing codes from Vision and TPP practices. However, there is literature showing that all long covid codes are poorly used (https://doi.org/10.3399%2FBJGP.2021.0301 and https://www.adruk.org/fileadmin/uploads/adruk/Documents/Data_Insights/Clinical_coding_and_capture_of_Long_COVID_V.3__4_.pdf).
+
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------: | ----------------: |
+| 2023-09-12 | EMIS            | 2463856    |   16167 (0.656%) |    16176 (0.657%) |
+| 2023-09-12 | TPP             | 200590     |    11 (0.00548%) |      425 (0.212%) |
+| 2023-09-12 | Vision          | 332095     |     467 (0.141%) |       498 (0.15%) |

--- a/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.ctv3.txt
+++ b/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.ctv3.txt
@@ -1,0 +1,3 @@
+Y2b88	Signposting to Your COVID Recovery
+Y2b89	Referral to post-COVID assessment clinic
+Y2b8a	Referral to Your COVID Recovery rehabilitation platform

--- a/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.emis.txt
+++ b/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.emis.txt
@@ -1,0 +1,4 @@
+^ESCT1348626	Referral to Your COVID Recovery rehabilitation platform
+^ESCT1348624	Signposting to Your COVID Recovery
+^ESCT1348625	Referral to post-COVID assessment clinic
+^ESCT1425920	Referral to long term effects of COVID-19 assessment clinic

--- a/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.readv2.txt
+++ b/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.readv2.txt
@@ -1,0 +1,3 @@
+8HTE600	Refer post-COVID assess clinic
+8HkjG00	Signposting Your COVID Recover
+8HkI.00	Referral to Your COVID Recovery rehabilitation platform 

--- a/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.snomed.txt
+++ b/shared/clinical-code-sets/patient/long-covid-referral/1/long-covid-referral.snomed.txt
@@ -1,0 +1,3 @@
+1325021000000106	Signposting to Your COVID Recovery
+1325031000000108	Referral to post-COVID assessment clinic
+1325041000000104	Referral to Your COVID Recovery rehabilitation platform


### PR DESCRIPTION
Breaking long-covid into 3 separate code sets: diagnosis, assessment and referral. This is in line with a couple of papers published on this so far.