### PR TITLE
Update height and weight queries

### DIFF
--- a/shared/Reusable queries for data extraction/query-get-closest-diagnosis-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-diagnosis-to-date.sql
@@ -6,9 +6,6 @@
 -- OBJECTIVE: To find the first diagnosis for a particular disease for every patient.
 
 -- INPUT: A variable:
---  - min-value: number - the smallest permitted value. Values lower than this will be disregarded.
---  - max-value: number - the largest permitted value. Values higher than this will be disregarded.
---  - unit: string - if a particular unit is required can enter it here. If any then use '%'
 --  - date: date - (YYYY-MM-DD) the date to look around
 --  - comparison: inequality sign (>, <, >= or <=) e.g. if '>' then will look for the first value strictly after the date
 --	-	all-patients: boolean - (true/false) if true, then all patients are included, otherwise only those in the pre-existing #Patients table.
@@ -42,12 +39,6 @@ INTO {param:temp-table-name}TEMP1
 FROM {param:gp-events-table}
 WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = '{param:code-set}' AND Version = {param:version}) 
 AND EventDate {param:comparison} '{param:date}'
-AND [Value] IS NOT NULL
-AND [Value] != '0'
-AND Units LIKE '{param:unit}'
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) >= {param:min-value}
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) <= {param:max-value}
 GROUP BY FK_Patient_Link_ID;
 
 -- Then we join to that table in order to get the value of that measurement

--- a/shared/Reusable queries for data extraction/query-get-closest-diagnosis-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-diagnosis-to-date.sql
@@ -1,9 +1,9 @@
 {if:verbose}
---┌───────────────────────────────────────────────┐
---│ Find the closest value to a particular date   │
---└───────────────────────────────────────────────┘
+--┌───────────────────────────────────────────────────┐
+--│ Find the closest diagnosis to a particular date   │
+--└───────────────────────────────────────────────────┘
 
--- OBJECTIVE: To find the first diagnosis for a particular disease for every patient.
+-- OBJECTIVE: To find the closest diagnosis for a particular disease and a given date.
 
 -- INPUT: A variable:
 --  - date: date - (YYYY-MM-DD) the date to look around

--- a/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
@@ -3,7 +3,7 @@
 --│ Find the closest value to a particular date   │
 --└───────────────────────────────────────────────┘
 
--- OBJECTIVE: To find the first diagnosis for a particular disease for every patient.
+-- OBJECTIVE: To find the closest value for a particular test to a given date.
 
 -- INPUT: A variable:
 --  - min-value: number - the smallest permitted value. Values lower than this will be disregarded.

--- a/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
@@ -45,6 +45,7 @@ AND EventDate {param:comparison} '{param:date}'
 AND [Value] IS NOT NULL
 AND [Value] != '0'
 AND Units LIKE '{param:unit}'
+-- as these are all tests, we can ignore values of zero and values outside the specified range
 AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
 AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) >= {param:min-value}
 AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) <= {param:max-value}

--- a/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
@@ -45,8 +45,7 @@ AND EventDate {param:comparison} '{param:date}'
 AND [Value] IS NOT NULL
 AND [Value] != '0'
 AND Units LIKE '{param:unit}'
--- as these are all tests, we can ignore values of zero and values outside the specified range
-AND TRY_CONVERT(DECIMAL(10,3), [Value]) != 0
+-- as these are all tests, we can ignore values values outside the specified range
 AND TRY_CONVERT(DECIMAL(10,3), [Value]) >= {param:min-value}
 AND TRY_CONVERT(DECIMAL(10,3), [Value]) <= {param:max-value}
 GROUP BY FK_Patient_Link_ID;

--- a/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
+++ b/shared/Reusable queries for data extraction/query-get-closest-value-to-date.sql
@@ -46,9 +46,9 @@ AND [Value] IS NOT NULL
 AND [Value] != '0'
 AND Units LIKE '{param:unit}'
 -- as these are all tests, we can ignore values of zero and values outside the specified range
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) >= {param:min-value}
-AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) <= {param:max-value}
+AND TRY_CONVERT(DECIMAL(10,3), [Value]) != 0
+AND TRY_CONVERT(DECIMAL(10,3), [Value]) >= {param:min-value}
+AND TRY_CONVERT(DECIMAL(10,3), [Value]) <= {param:max-value}
 GROUP BY FK_Patient_Link_ID;
 
 -- Then we join to that table in order to get the value of that measurement

--- a/shared/Reusable queries for data extraction/query-get-height.sql
+++ b/shared/Reusable queries for data extraction/query-get-height.sql
@@ -33,7 +33,7 @@ FROM {param:gp-events-table}
 WHERE Units IS NULL 
 	AND Value IS NOT NULL
 	AND Value <> ''
-	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
+	AND TRY_CONVERT(DECIMAL(10,3), [Value]) != 0
 	AND EventDate <= '{param:date}'
 	AND SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
 {if:all-patients=false}
@@ -62,10 +62,10 @@ IF OBJECT_ID('tempdb..#PatientHeight') IS NOT NULL DROP TABLE #PatientHeight;
 SELECT 
 	CASE WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.FK_Patient_Link_ID ELSE hm.FK_Patient_Link_ID END AS FK_Patient_Link_ID,
 	CASE
-		WHEN hm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), stuff(hcm.[Value], 1, patindex('%[0-9]%', hcm.[Value])-1, ''))
-		WHEN hcm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), stuff(hm.[Value], 1, patindex('%[0-9]%', hm.[Value])-1, '')) * 100
-		WHEN hm.DateOfFirstValue > hcm.DateOfFirstValue THEN TRY_CONVERT(DECIMAL(10,3), stuff(hm.[Value], 1, patindex('%[0-9]%', hm.[Value])-1, '')) * 100
-		ELSE TRY_CONVERT(DECIMAL(10,3), stuff(hcm.[Value], 1, patindex('%[0-9]%', hcm.[Value])-1, ''))
+		WHEN hm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), hcm.[Value])
+		WHEN hcm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), hm.[Value]) * 100
+		WHEN hm.DateOfFirstValue > hcm.DateOfFirstValue THEN TRY_CONVERT(DECIMAL(10,3), hm.[Value]) * 100
+		ELSE TRY_CONVERT(DECIMAL(10,3), hcm.[Value])
 	END AS HeightInCentimetres,
 	CASE
 		WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.DateOfFirstValue
@@ -79,9 +79,9 @@ FULL JOIN #PatientHeightInMetres hm ON hm.FK_Patient_Link_ID = hcm.FK_Patient_Li
 UNION ALL
 SELECT 
 	hno.FK_Patient_Link_ID,
-	CASE WHEN (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, ''))) BETWEEN 0.01 AND 2.5 
-	THEN (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, ''))) * 100 
-		ELSE (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')))
+	CASE WHEN (TRY_CONVERT(DECIMAL(10,3), [Value])) BETWEEN 0.01 AND 2.5 
+	THEN (TRY_CONVERT(DECIMAL(10,3), [Value])) * 100 
+		ELSE (TRY_CONVERT(DECIMAL(10,3), [Value]))
 		END,
 	HeightDate = DateOfFirstValue
 FROM #PatientHeightNoUnits hno

--- a/shared/Reusable queries for data extraction/query-get-height.sql
+++ b/shared/Reusable queries for data extraction/query-get-height.sql
@@ -6,23 +6,65 @@
 -- OBJECTIVE: Gets the most recent measurement of a person's height
 
 -- INPUT: A variable:
+--  -   date: date - (yyyy-mm-dd) the date for which you want to find the most recent measurement 
 --  -	all-patients: boolean - (true/false) if true, then all patients are included, otherwise only those in the pre-existing #Patients table.
 --  -	gp-events-table: string - (table name) the name of the table containing the GP events. Usually is "SharedCare.GP_Events" but can be anything with the columns: FK_Patient_Link_ID, EventDate, and SuppliedCode
 
 -- OUTPUT: Temp table called #PatientHeight with columns:
 --	-	FK_Patient_Link_ID - unique patient id
---	- HeightInCentimetres - int - the most recent height in cm
---	-	HeightDate - date (YYYY/MM/DD) - the date of the most recent height measurement
+--	-   HeightInCentimetres - int - the most recent height measurement before the specified date, in cm
+--	-	HeightDate - date (YYYY/MM/DD) - the date of the most recent height measurement before the specified date
 {endif:verbose}
+
+--> CODESET height:1    -- this code set also gets added in lines 32 and 35, but doing it here allows us to create the #GPEvents table directly below
+
+-- Create a smaller version of GP event table===========================================================================================================
+IF OBJECT_ID('tempdb..#GPEvents') IS NOT NULL DROP TABLE #GPEvents;
+SELECT gp.FK_Patient_Link_ID, EventDate, SuppliedCode, FK_Reference_Coding_ID, FK_Reference_SnomedCT_ID, [Value], Units
+INTO #GPEvents
+FROM SharedCare.GP_Events gp
+	WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
+	AND gp.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+
 
 -- Height is almost always recorded in either metres or centimetres, so
 -- first we get the most recent value for height where the unit is 'm'
---> EXECUTE query-get-most-recent-value.sql min-value:0.01 max-value:2.5 unit:m all-patients:{param:all-patients} gp-events-table:{param:gp-events-table} code-set:height version:1 max-or-min:max temp-table-name:#PatientHeightInMetres
+--> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:0.01 max-value:2.5 unit:m date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInMetres
 
 -- Now we do the same but for 'cm'
---> EXECUTE query-get-most-recent-value.sql min-value:10 max-value:250 unit:cm all-patients:{param:all-patients} gp-events-table:{param:gp-events-table} code-set:height version:1 max-or-min:max temp-table-name:#PatientHeightInCentimetres
-
+--> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:10 max-value:250 unit:cm date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInCentimetres
 -- NB the units are standardised so 'm' and 'cm' dominate. You do not get units like 'metres'.
+
+-- now include records that don't have a unit value but have a height recording (there are only useful records with NULL for unit, not a blank value)
+
+IF OBJECT_ID('tempdb..#PatientHeightNoUnitsTEMP1') IS NOT NULL DROP TABLE #PatientHeightNoUnitsTEMP1;
+SELECT  FK_Patient_Link_ID, MAX(EventDate) AS EventDate
+INTO #PatientHeightNoUnitsTEMP1
+FROM {param:gp-events-table} 
+WHERE Units IS NULL 
+	AND Value IS NOT NULL
+	AND Value <> ''
+	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
+	AND EventDate <= '{param:date}'
+	AND SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
+{if:all-patients=false}
+AND FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+{endif:all-patients}
+GROUP BY FK_Patient_Link_ID
+
+IF OBJECT_ID('tempdb..#PatientHeightNoUnits') IS NOT NULL DROP TABLE #PatientHeightNoUnits;
+SELECT p.FK_Patient_Link_ID, p.EventDate AS DateOfFirstValue, MAX(p.Value) AS [Value]
+INTO #PatientHeightNoUnits
+FROM {param:gp-events-table} p
+INNER JOIN #PatientHeightNoUnitsTEMP1 sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.EventDate = p.EventDate
+WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
+{if:patients}
+AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM {param:patients})
+{endif:patients}
+{if:all-patients=false}
+AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+{endif:all-patients}
+GROUP BY p.FK_Patient_Link_ID, p.EventDate;
 
 -- Create the output PatientHeight temp table. We combine the m and cm tables from above
 -- to find the most recent height for each person. We multiply the height in metres by 100
@@ -31,17 +73,26 @@ IF OBJECT_ID('tempdb..#PatientHeight') IS NOT NULL DROP TABLE #PatientHeight;
 SELECT 
 	CASE WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.FK_Patient_Link_ID ELSE hm.FK_Patient_Link_ID END AS FK_Patient_Link_ID,
 	CASE
-		WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.MostRecentValue
-		WHEN hcm.FK_Patient_Link_ID IS NULL THEN hm.MostRecentValue * 100
-		WHEN hm.MostRecentDate > hcm.MostRecentDate THEN hm.MostRecentValue * 100
-		ELSE hcm.MostRecentValue
+		WHEN hm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), stuff(hcm.[Value], 1, patindex('%[0-9]%', hcm.[Value])-1, ''))
+		WHEN hcm.FK_Patient_Link_ID IS NULL THEN TRY_CONVERT(DECIMAL(10,3), stuff(hm.[Value], 1, patindex('%[0-9]%', hm.[Value])-1, '')) * 100
+		WHEN hm.DateOfFirstValue > hcm.DateOfFirstValue THEN TRY_CONVERT(DECIMAL(10,3), stuff(hm.[Value], 1, patindex('%[0-9]%', hm.[Value])-1, '')) * 100
+		ELSE TRY_CONVERT(DECIMAL(10,3), stuff(hcm.[Value], 1, patindex('%[0-9]%', hcm.[Value])-1, ''))
 	END AS HeightInCentimetres,
 	CASE
-		WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.MostRecentDate
-		WHEN hcm.FK_Patient_Link_ID IS NULL THEN hm.MostRecentDate
-		WHEN hm.MostRecentDate > hcm.MostRecentDate THEN hm.MostRecentDate
-		ELSE hcm.MostRecentDate
+		WHEN hm.FK_Patient_Link_ID IS NULL THEN hcm.DateOfFirstValue
+		WHEN hcm.FK_Patient_Link_ID IS NULL THEN hm.DateOfFirstValue
+		WHEN hm.DateOfFirstValue > hcm.DateOfFirstValue THEN hm.DateOfFirstValue
+		ELSE hcm.DateOfFirstValue
 	END AS HeightDate
 INTO #PatientHeight
 FROM #PatientHeightInCentimetres hcm
-FULL JOIN #PatientHeightInMetres hm ON hm.FK_Patient_Link_ID = hcm.FK_Patient_Link_ID;
+FULL JOIN #PatientHeightInMetres hm ON hm.FK_Patient_Link_ID = hcm.FK_Patient_Link_ID
+UNION ALL
+SELECT 
+	hno.FK_Patient_Link_ID,
+	CASE WHEN (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, ''))) BETWEEN 0.01 AND 2.5 
+	THEN (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, ''))) * 100 
+		ELSE (TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')))
+		END,
+	HeightDate = DateOfFirstValue
+FROM #PatientHeightNoUnits hno

--- a/shared/Reusable queries for data extraction/query-get-height.sql
+++ b/shared/Reusable queries for data extraction/query-get-height.sql
@@ -16,17 +16,6 @@
 --	-	HeightDate - date (YYYY/MM/DD) - the date of the most recent height measurement before the specified date
 {endif:verbose}
 
---> CODESET height:1    -- this code set also gets added in lines 32 and 35, but doing it here allows us to create the #GPEvents table directly below
-
--- Create a smaller version of GP event table===========================================================================================================
-IF OBJECT_ID('tempdb..#GPEvents') IS NOT NULL DROP TABLE #GPEvents;
-SELECT gp.FK_Patient_Link_ID, EventDate, SuppliedCode, FK_Reference_Coding_ID, FK_Reference_SnomedCT_ID, [Value], Units
-INTO #GPEvents
-FROM SharedCare.GP_Events gp
-	WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
-	AND gp.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
-
-
 -- Height is almost always recorded in either metres or centimetres, so
 -- first we get the most recent value for height where the unit is 'm'
 --> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:0.01 max-value:2.5 unit:m date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInMetres

--- a/shared/Reusable queries for data extraction/query-get-height.sql
+++ b/shared/Reusable queries for data extraction/query-get-height.sql
@@ -18,10 +18,10 @@
 
 -- Height is almost always recorded in either metres or centimetres, so
 -- first we get the most recent value for height where the unit is 'm'
---> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:0.01 max-value:2.5 unit:m date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInMetres
+--> EXECUTE query-get-closest-value-to-date.sql all-patients:{param:all-patients} min-value:0.01 max-value:2.5 unit:m date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInMetres
 
 -- Now we do the same but for 'cm'
---> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:10 max-value:250 unit:cm date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInCentimetres
+--> EXECUTE query-get-closest-value-to-date.sql all-patients:{param:all-patients} min-value:10 max-value:250 unit:cm date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:height version:1 temp-table-name:#PatientHeightInCentimetres
 -- NB the units are standardised so 'm' and 'cm' dominate. You do not get units like 'metres'.
 
 -- now include records that don't have a unit value but have a height recording (there are only useful records with NULL for unit, not a blank value)
@@ -47,12 +47,6 @@ INTO #PatientHeightNoUnits
 FROM {param:gp-events-table} p
 INNER JOIN #PatientHeightNoUnitsTEMP1 sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.EventDate = p.EventDate
 WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'height' AND Version = 1) 
-{if:patients}
-AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM {param:patients})
-{endif:patients}
-{if:all-patients=false}
-AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
-{endif:all-patients}
 GROUP BY p.FK_Patient_Link_ID, p.EventDate;
 
 -- Create the output PatientHeight temp table. We combine the m and cm tables from above

--- a/shared/Reusable queries for data extraction/query-get-weight.sql
+++ b/shared/Reusable queries for data extraction/query-get-weight.sql
@@ -58,7 +58,7 @@ GROUP BY p.FK_Patient_Link_ID, p.EventDate;
 IF OBJECT_ID('tempdb..#PatientWeight') IS NOT NULL DROP TABLE #PatientWeight;
 SELECT 
 	wkg.FK_Patient_Link_ID,
-	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3),wno.[Value]),
+	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3),wkg.[Value]),
 	WeightDate = wkg.DateOfFirstValue 
 INTO #PatientWeight
 FROM #PatientWeightInKilograms wkg

--- a/shared/Reusable queries for data extraction/query-get-weight.sql
+++ b/shared/Reusable queries for data extraction/query-get-weight.sql
@@ -32,7 +32,6 @@ WHERE Units IS NULL
 	AND Value IS NOT NULL
 	AND Value <> ''
 	AND TRY_CONVERT(DECIMAL(10,3), [Value]) BETWEEN 0.1 AND 500
-	AND TRY_CONVERT(DECIMAL(10,3), [Value]) != 0
 	AND EventDate <= '{param:date}'
 	AND SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
 {if:all-patients=false}
@@ -46,12 +45,6 @@ INTO #PatientWeightNoUnits
 FROM {param:gp-events-table} p
 INNER JOIN #PatientWeightNoUnitsTEMP1 sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.EventDate = p.EventDate
 WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
-{if:patients}
-AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM {param:patients})
-{endif:patients}
-{if:all-patients=false}
-AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
-{endif:all-patients}
 GROUP BY p.FK_Patient_Link_ID, p.EventDate;
 
 -- Create the output PatientWeight temp table, with vlaues in kg. We combine the kg and 'no unit' tables from above.

--- a/shared/Reusable queries for data extraction/query-get-weight.sql
+++ b/shared/Reusable queries for data extraction/query-get-weight.sql
@@ -1,0 +1,84 @@
+{if:verbose}
+--┌──────────────────────────┐
+--│ Gets a patient's Weight  │
+--└──────────────────────────┘
+
+-- OBJECTIVE: Gets the most recent measurement of a person's Weight, in kilograms
+
+-- INPUT: A variable:
+--  -   date: date - (yyyy-mm-dd) the date for which you want to find the most recent measurement 
+--  -	all-patients: boolean - (true/false) if true, then all patients are included, otherwise only those in the pre-existing #Patients table.
+--  -	gp-events-table: string - (table name) the name of the table containing the GP events. Usually is "SharedCare.GP_Events" but can be anything with the columns: FK_Patient_Link_ID, EventDate, and SuppliedCode
+
+-- OUTPUT: Temp table called #PatientWeight with columns:
+--	-	FK_Patient_Link_ID - unique patient id
+--	-   WeightInKilograms - int - the most recent Weight measurement before the specified date, in kg
+--	-	WeightDate - date (YYYY/MM/DD) - the date of the most recent Weight measurement before the specified date
+{endif:verbose}
+
+--> CODESET weight:1 
+-- this code set also gets added in lines 32 and 35, but doing it here allows us to create the #GPEvents table directly below
+
+-- Create a smaller version of GP event table===========================================================================================================
+IF OBJECT_ID('tempdb..#GPEvents') IS NOT NULL DROP TABLE #GPEvents;
+SELECT gp.FK_Patient_Link_ID, EventDate, SuppliedCode, FK_Reference_Coding_ID, FK_Reference_SnomedCT_ID, [Value], Units
+INTO #GPEvents
+FROM SharedCare.GP_Events gp
+	WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
+	AND gp.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+
+
+-- Weight is almost always recorded in kilograms, so
+-- first we get the most recent value for Weight where the unit is 'kg'
+--> EXECUTE query-get-closest-value-to-date.sql all-patients:false min-value:0.1 max-value:500 unit:kg date:{param:date} comparison:<= gp-events-table:{param:gp-events-table} code-set:weight version:1 temp-table-name:#PatientWeightInKilograms
+
+-- NB the units are standardised so 'kg' dominates. You do not get units like 'kilograms'.
+
+-- now include records that don't have a unit value but have a Weight recording (there are only useful records with NULL for unit, not a blank value)
+
+IF OBJECT_ID('tempdb..#PatientWeightNoUnitsTEMP1') IS NOT NULL DROP TABLE #PatientWeightNoUnitsTEMP1;
+SELECT  FK_Patient_Link_ID, MAX(EventDate) AS EventDate
+INTO #PatientWeightNoUnitsTEMP1
+FROM {param:gp-events-table} 
+WHERE Units IS NULL 
+	AND Value IS NOT NULL
+	AND Value <> ''
+	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) BETWEEN 0.1 AND 500
+	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
+	AND EventDate <= '{param:date}'
+	AND SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
+{if:all-patients=false}
+AND FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+{endif:all-patients}
+GROUP BY FK_Patient_Link_ID
+
+IF OBJECT_ID('tempdb..#PatientWeightNoUnits') IS NOT NULL DROP TABLE #PatientWeightNoUnits;
+SELECT p.FK_Patient_Link_ID, p.EventDate AS DateOfFirstValue, MAX(p.Value) AS [Value]
+INTO #PatientWeightNoUnits
+FROM {param:gp-events-table} p
+INNER JOIN #PatientWeightNoUnitsTEMP1 sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.EventDate = p.EventDate
+WHERE SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
+{if:patients}
+AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM {param:patients})
+{endif:patients}
+{if:all-patients=false}
+AND p.FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+{endif:all-patients}
+GROUP BY p.FK_Patient_Link_ID, p.EventDate;
+
+-- Create the output PatientWeight temp table. We combine the m and cm tables from above
+-- to find the most recent Weight for each person. We multiply the Weight in metres by 100
+-- to standardise the output to Kilograms.
+IF OBJECT_ID('tempdb..#PatientWeight') IS NOT NULL DROP TABLE #PatientWeight;
+SELECT 
+	wkg.FK_Patient_Link_ID,
+	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3), stuff(wkg.[Value], 1, patindex('%[0-9]%', wkg.[Value])-1, '')),
+	WeightDate = wkg.DateOfFirstValue 
+INTO #PatientWeight
+FROM #PatientWeightInKilograms wkg
+UNION ALL
+SELECT 
+	wno.FK_Patient_Link_ID,
+	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')),
+	WeightDate = DateOfFirstValue
+FROM #PatientWeightNoUnits wno

--- a/shared/Reusable queries for data extraction/query-get-weight.sql
+++ b/shared/Reusable queries for data extraction/query-get-weight.sql
@@ -31,8 +31,8 @@ FROM {param:gp-events-table}
 WHERE Units IS NULL 
 	AND Value IS NOT NULL
 	AND Value <> ''
-	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) BETWEEN 0.1 AND 500
-	AND TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')) != 0
+	AND TRY_CONVERT(DECIMAL(10,3), [Value]) BETWEEN 0.1 AND 500
+	AND TRY_CONVERT(DECIMAL(10,3), [Value]) != 0
 	AND EventDate <= '{param:date}'
 	AND SuppliedCode IN (SELECT code FROM #AllCodes WHERE Concept = 'weight' AND Version = 1) 
 {if:all-patients=false}
@@ -58,13 +58,13 @@ GROUP BY p.FK_Patient_Link_ID, p.EventDate;
 IF OBJECT_ID('tempdb..#PatientWeight') IS NOT NULL DROP TABLE #PatientWeight;
 SELECT 
 	wkg.FK_Patient_Link_ID,
-	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3), stuff(wkg.[Value], 1, patindex('%[0-9]%', wkg.[Value])-1, '')),
+	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3),wno.[Value]),
 	WeightDate = wkg.DateOfFirstValue 
 INTO #PatientWeight
 FROM #PatientWeightInKilograms wkg
 UNION ALL
 SELECT 
 	wno.FK_Patient_Link_ID,
-	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3), stuff([Value], 1, patindex('%[0-9]%', [Value])-1, '')),
+	WeightInKilograms = TRY_CONVERT(DECIMAL(10,3),wno.[Value]),
 	WeightDate = DateOfFirstValue
 FROM #PatientWeightNoUnits wno


### PR DESCRIPTION
Previously the height query was affected by a conversion error. This code fixes that, and also incorporates records where the Unit is NULL but the value looks like cm/m.

This query also does the same for weight, but no conversion is needed as the value is always in kg.

These queries also allow a data parameter - to find the closest value before that date.

These queries make use of the 'query-get-closest-value-to-date' reusable queries, which have been split out into a diagnosis query and a tests query.