### PR TITLE
Rq051 data refresh

### DIFF
--- a/projects/051 - Webb/README.html
+++ b/projects/051 - Webb/README.html
@@ -290,10 +290,10 @@ Prior to data extraction, the code is checked and signed off by another RDE.</p>
 </ul>
 <p>Further details for each code set can be found below.</p>
 <h3>Anxiety</h3>
-<p>Any code indicating a diagnosis of anxiety or other somatoform disorder.</p>
+<p>Any code indicating a diagnosis of anxiety or other somatoform disorder. Developed from SNOMED searches and the opencodelist code set: https://www.opencodelists.org/codelist/opensafely/anxiety-disorders/6aef605a/.</p>
 <h4>Prevalence log</h4>
 <p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.</p>
-<p>The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range <code>18.23% - 18.77%</code> suggests that this code set is well defined.</p>
+<p>The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range <code>21.3% - 22%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -324,18 +324,49 @@ Prior to data extraction, the code is checked and signed off by another RDE.</p>
 <td>Vision</td>
 <td>342344</td>
 <td style="text-align:right">65130 (19.02%)</td>
-<td style="text-align:right">64271 (18.77%))</td>
+<td style="text-align:right">64271 (18.77%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">766186 (30.3%)</td>
+<td style="text-align:right">549512 (21.7%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">46335 (23%)</td>
+<td style="text-align:right">42913 (21.3%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">77888 (23.2%)</td>
+<td style="text-align:right">73817 (22%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/anxiety/1">https://github.com/rw251/.../conditions/anxiety/1</a></p>
 <h3>Depression</h3>
 <p>Code set for patients with a diagnosis of depression.</p>
 <p>Developed from www.opencodelists.org</p>
+<ul>
+<li>No &quot;affective disorder&quot; codes unless mention of depression e.g. 191632009: Bipolar affective disorder, currently depressed, severe, with psychosis (disorder)</li>
+<li>Seasonal affective disorder included as that is a depressive condition</li>
+<li>Includes non-diagnosis codes such as monitoring invites</li>
+<li>Codes indicating grief from bereavement or other life events are included on the grounds that if they are coded in a person's record they are likely clinically important</li>
+</ul>
 <h4>Prevalence log</h4>
 <p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system,
 we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.
-Prevalence range: 21.09% - 22.83%</p>
+The prevalence range <code>23% - 25%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -369,20 +400,38 @@ Prevalence range: 21.09% - 22.83%</p>
 <td>73277 (21.40%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/depression/1">https://github.com/rw251/.../conditions/depression/1</a></td>
-<td></td>
-<td></td>
-<td></td>
-<td></td>
+<td>2024-01-19</td>
+<td>EMIS</td>
+<td>2519438</td>
+<td>676518 (26.9%)</td>
+<td>572943 (22.7%)</td>
+</tr>
+<tr>
+<td>2024-01-19</td>
+<td>TPP</td>
+<td>201469</td>
+<td>51022 (25.3%)</td>
+<td>50682 (25.2%)</td>
+</tr>
+<tr>
+<td>2024-01-19</td>
+<td>Vision</td>
+<td>334528</td>
+<td>80546 (24.1%)</td>
+<td>78271 (23.4%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-01-17</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/depression/1">https://github.com/rw251/.../conditions/depression/1</a></p>
 <h3>Schizophrenia and Psychosis</h3>
 <p>Code set for patients with a diagnosis of psychosis or schizophrenia.</p>
 <p>Developed from www.opencodelists.org</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions.
-Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. The prevalence range <code>1% - 1.3%</code> suggests this is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -415,14 +464,39 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td>49565 (1.90%)</td>
 <td>49565 (1.90%)</td>
 </tr>
+<tr>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td>42592 (1.68%)</td>
+<td>25346 (1%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td>2709 (1.34%)</td>
+<td>2692 (1.33%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td>5057 (1.51%)</td>
+<td>3253 (0.97%)</td>
+</tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/schizophrenia-psychosis/1">https://github.com/rw251/.../conditions/schizophrenia-psychosis/1</a></p>
 <h3>Bipolar affective disorder</h3>
 <p>Code set for patients with a diagnosis of bipolar.</p>
-<p>Developed from www.opencodelists.org</p>
+<p>Developed from www.opencodelists.org and the NHS PCD refsets.</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. Prevalence range: 0.28% - 0.54%</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. Prevalence range: <code>0.28% - 0.31%</code> suggests this is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -455,14 +529,42 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td>1608 (0.48%)</td>
 <td>1608 (0.48%)</td>
 </tr>
+<tr>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td>322887 (12.8%)</td>
+<td>7791 (0.308%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td>1096 (0.543%)</td>
+<td>570 (0.282%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td>8076 (2.41%)</td>
+<td>972 (0.29%)</td>
+</tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/bipolar/1">https://github.com/rw251/.../conditions/bipolar/1</a></p>
 <h3>Eating disorders</h3>
-<p>Any code indicating a diagnosis of anorexia or bulimia or similar eating disorders.</p>
+<p>Any code indicating a diagnosis of anorexia or bulimia or similar eating disorders. SNOMED codes from the NHS PCD refset.</p>
+<ul>
+<li>Does not include &quot;loss of appetite codes&quot; unless there is an indication that it is a symptom of anorexia.</li>
+</ul>
 <h4>Prevalence log</h4>
 <p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.</p>
-<p>The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range <code>0.42% - 0.84%</code> suggests that this code set is well defined.</p>
+<p>The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range <code>0.68% - 0.85%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -495,16 +597,40 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">1999 (0.58%)</td>
 <td style="text-align:right">1935 (0.57%)</td>
 </tr>
+<tr>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">34267 (1.35%)</td>
+<td style="text-align:right">21377 (0.845%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">3067 (1.52%)</td>
+<td style="text-align:right">1362 (0.675%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">3719 (1.11%)</td>
+<td style="text-align:right">2472 (0.737%)</td>
+</tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/eating-disorders/1">https://github.com/rw251/.../conditions/eating-disorders/1</a></p>
 <h3>Self-harm Episodes</h3>
 <p>Defined as any episode of self-harm (except accidental) or attempted suicide</p>
 <p>Readv2 code set supplied by the PI for RQ-029(Steeg)</p>
 <p>CTV3 and SNOMED code sets created using the Reference_Coding table in the GMCR, based on the Readv2 code set.</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.</p>
-<p>The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. The prevalence range <code>3.83% - 4.17%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -538,18 +664,38 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">11975 (3.59%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/patient/selfharm-episodes/1">https://github.com/rw251/.../patient/selfharm-episodes/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">105617 (4.17%)</td>
+<td style="text-align:right">105491 (4.17%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">8865 (4.39%)</td>
+<td style="text-align:right">8072 (4%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">12867 (3.84%)</td>
+<td style="text-align:right">12836 (3.83%)</td>
 </tr>
 </tbody>
 </table>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/patient/selfharm-episodes/1">https://github.com/rw251/.../patient/selfharm-episodes/1</a></p>
 <h3>Attention deficit hyperactivity disorder</h3>
 <p>This code set was created from getset.ga.</p>
+<ul>
+<li>Includes codes suggesting ADHD such as monitoring letters and annual reviews</li>
+<li>Does not include ADHD assessment scales</li>
+<li>Includes attention deficit disorder (i.e. without hyperactivity). This might not be what you want.</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.70 - 0.78%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>1.08 - 1.39%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -562,39 +708,61 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 </thead>
 <tbody>
 <tr>
-<td>2022-09-27</td>
+<td>2024-01-19</td>
 <td>EMIS</td>
-<td>2449912</td>
-<td style="text-align:right">17633 (0.71%)</td>
-<td style="text-align:right">17132 (0.70%)</td>
+<td>2519438</td>
+<td style="text-align:right">25644 (1.02%)</td>
+<td style="text-align:right">25648 (1.02%)</td>
 </tr>
 <tr>
-<td>2022-09-27</td>
+<td>2024-01-19</td>
 <td>TPP</td>
-<td>198140</td>
-<td style="text-align:right">1474 (0.74%)</td>
-<td style="text-align:right">1555(0.78%)</td>
+<td>201469</td>
+<td style="text-align:right">2059 (1.02%)</td>
+<td style="text-align:right">2066 (1.03%)</td>
 </tr>
 <tr>
-<td>2022-09-27</td>
+<td>2024-01-19</td>
 <td>Vision</td>
-<td>325784</td>
-<td style="text-align:right">2966 (0.91%)</td>
-<td style="text-align:right">2457(0.75%)</td>
+<td>334528</td>
+<td style="text-align:right">4394 (1.31%)</td>
+<td style="text-align:right">4377 (1.31%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/attention-deficit-hyperactivity-disorder/1">https://github.com/rw251/.../conditions/attention-deficit-hyperactivity-disorder/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">27454 (1.08%)</td>
+<td style="text-align:right">27454 (1.08%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">2147 (1.06%)</td>
+<td style="text-align:right">2153 (1.07%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">4674 (1.39%)</td>
+<td style="text-align:right">4657 (1.39%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/attention-deficit-hyperactivity-disorder/1">https://github.com/rw251/.../conditions/attention-deficit-hyperactivity-disorder/1</a></p>
 <h3>Autism spectrum disorder</h3>
 <p>This code set was created from getset.ga.</p>
+<ul>
+<li>Includes &quot;suspected autism&quot; codes. This might not be what you want.</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.80 - 0.89%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>1.17 - 1.28%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -628,23 +796,65 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">2614 (0.80%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/autism-spectrum-disorder/1">https://github.com/rw251/.../conditions/autism-spectrum-disorder/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-01-19</td>
+<td>EMIS</td>
+<td>2519438</td>
+<td style="text-align:right">30794 (1.22%)</td>
+<td style="text-align:right">30797 (1.22%)</td>
+</tr>
+<tr>
+<td>2024-01-19</td>
+<td>TPP</td>
+<td>201469</td>
+<td style="text-align:right">2239 (1.11%)</td>
+<td style="text-align:right">2239 (1.11%)</td>
+</tr>
+<tr>
+<td>2024-01-19</td>
+<td>Vision</td>
+<td>334528</td>
+<td style="text-align:right">3851 (1.15%)</td>
+<td style="text-align:right">3840 (1.15%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">32491 (1.28%)</td>
+<td style="text-align:right">32491 (1.28%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">2359 (1.17%)</td>
+<td style="text-align:right">2359 (1.17%)</td>
+</tr>
+<tr>
+<td>2024-04-30</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">4183 (1.25%)</td>
+<td style="text-align:right">4171 (1.24%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-04-30</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/autism-spectrum-disorder/1">https://github.com/rw251/.../conditions/autism-spectrum-disorder/1</a></p>
 <h3>Monoamine Axidase Inhibitors (MAOI)</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Iproniazid
--- Isocarboxazid
--- Moclobemide
--- Phenelzine sulfate
--- Selegiline hydrochloride
--- Tranylcypromine sulfate
--- Trifluoperazine Hydrochloride/Tranylcypromine Sulphate</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Iproniazid (marsilid)</li>
+<li>Isocarboxazid (marplan)</li>
+<li>Moclobemide (Manerix)</li>
+<li>Phenelzine sulfate (Nardil)</li>
+<li>Selegiline hydrochloride (Centrapryl/Eldepryl/Stilline/Vivapryl/Zelapar)</li>
+<li>Tranylcypromine sulfate (parnate)</li>
+<li>Trifluoperazine Hydrochloride/Tranylcypromine Sulphate (parstelin)</li>
+</ul>
 <h4>Prevalence log</h4>
 <p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.03 - 0.05%</code> suggests that this code set is well defined.</p>
 <table>
@@ -680,21 +890,42 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">107 (0.03%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/monoamine-oxidase-inhibitor/1">https://github.com/rw251/.../medications/monoamine-oxidase-inhibitor/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-07</td>
+<td>EMIS</td>
+<td>2516912</td>
+<td style="text-align:right">893 (0.0355%)</td>
+<td style="text-align:right">893 (0.0355%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>TPP</td>
+<td>200013</td>
+<td style="text-align:right">94 (0.047%)</td>
+<td style="text-align:right">94 (0.047%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>Vision</td>
+<td>334384</td>
+<td style="text-align:right">114 (0.0341%)</td>
+<td style="text-align:right">114 (0.0341%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-07</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/monoamine-oxidase-inhibitor/1">https://github.com/rw251/.../medications/monoamine-oxidase-inhibitor/1</a></p>
 <h3>Norepinephrine Reuptake Inhibitors (NRI)</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Atomoxetine hydrochloride
--- Reboxetine
--- Viloxazine Hydrochloride</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Atomoxetine hydrochloride (Strattera/Atomaid)</li>
+<li>Reboxetine (Edronax)</li>
+<li>Viloxazine Hydrochloride (Vivalan)</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.14 - 0.17%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.15 - 0.21%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -728,22 +959,41 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">534 (0.16%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/norepinephrine-reuptake-inhibitors/1">https://github.com/rw251/.../medications/norepinephrine-reuptake-inhibitors/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">3906 (0.154%)</td>
+<td style="text-align:right">3906 (0.154%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">381 (0.189%)</td>
+<td style="text-align:right">381 (0.189%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">687 (0.205%)</td>
+<td style="text-align:right">687 (0.205%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/norepinephrine-reuptake-inhibitors/1">https://github.com/rw251/.../medications/norepinephrine-reuptake-inhibitors/1</a></p>
 <h3>Serotonin Antagonist and Reuptake Inhibitors (SARI)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Nefazodone
+-- Nefazodone (Dutonin)
 -- Nefazodone hydrochloride
--- Trazodone
+-- Trazodone (Molipaxin)
 -- Trazodone hydrochloride</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.6 - 1.2%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.7 - 1.2%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -777,19 +1027,39 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">2032 (0.6%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-antagonist-reuptake-inhibitors/1">https://github.com/rw251/.../medications/serotonin-antagonist-reuptake-inhibitors/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">20341 (0.804%)</td>
+<td style="text-align:right">20341 (0.804%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">2384 (1.18%)</td>
+<td style="text-align:right">2384 (1.18%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">2448 (0.73%)</td>
+<td style="text-align:right">2448 (0.73%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-antagonist-reuptake-inhibitors/1">https://github.com/rw251/.../medications/serotonin-antagonist-reuptake-inhibitors/1</a></p>
 <h3>Serotonin Modulator and Stimulator (SMS)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
 -- Vortioxetine hydrobromide</p>
+<p><em>NB - at some point we should remove this code set as it is a duplicate of the vortioxetine code set.</em></p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.001 - 0.003%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.058% - 0.076%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -823,22 +1093,40 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">4 (0.001%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-modulator-stimulator/1">https://github.com/rw251/.../medications/serotonin-modulator-stimulator/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">1474 (0.0582%)</td>
+<td style="text-align:right">1474 (0.0582%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">154 (0.0763%)</td>
+<td style="text-align:right">154 (0.0763%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">211 (0.0629%)</td>
+<td style="text-align:right">211 (0.0629%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-modulator-stimulator/1">https://github.com/rw251/.../medications/serotonin-modulator-stimulator/1</a></p>
 <h3>Serotonin and Norepinephrine Reuptake Inhibitors (SNRI)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
 -- Desvenlafaxine
--- Duloxetine
--- Duloxetine hydrochloride
--- Venlafaxine hydrochloride</p>
+-- Duloxetine (Cymbalta/Dutor/Depalta/Duciltia/Yentreve)
+-- Venlafaxine hydrochloride (Alventa/Apclaven/Amphero/Bonilux/Depefex/Efexor/Foraven/Majoven/Mentaven/Politid/Ranfaxine/Rodomel/Sunveniz/Tardcaps/Tifaxin/Tonpular/Trixat/Vaxalin/Venaxx/Vencarm/Venlablue/Venladex/Venlalic/Venlaneo/Venlasov/Vensir/Venzip/Vexarin/ViePax)</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>3.57 - 4.35%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>4.0 - 4.4%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -872,28 +1160,47 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">11705 (3.59%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-norepinephrine-reuptake-inhibitors/1">https://github.com/rw251/.../medications/serotonin-norepinephrine-reuptake-inhibitors/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">100387 (3.97%)</td>
+<td style="text-align:right">100387 (3.97%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">8873 (4.4%)</td>
+<td style="text-align:right">8873 (4.4%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">14357 (4.28%)</td>
+<td style="text-align:right">14357 (4.28%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-norepinephrine-reuptake-inhibitors/1">https://github.com/rw251/.../medications/serotonin-norepinephrine-reuptake-inhibitors/1</a></p>
 <h3>Selective Serotonin Reuptake Inhibitors (SSRI)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Citalopram hydrobromide
+-- Citalopram hydrobromide (Cipramil)
 -- Citalopram hydrochloride
--- Escitalopram oxalate
--- Fluoxetine
+-- Escitalopram oxalate (Cipralex)
+-- Fluoxetine (Felicium/Olena/Oxactin/Prozep/Prozit/Ranflutin/Prozac)
 -- Fluoxetine hydrochloride
--- Fluvoxamine
+-- Fluvoxamine (Faverin)
 -- Fluvoxamine maleate
--- Paroxetine hydrochloride
--- Sertraline
+-- Paroxetine hydrochloride (Seroxat)
+-- Sertraline (Contulen/Lustral)
 -- Sertraline hydrochloride</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>21.1 - 26.6%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>22 - 26.1%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -927,40 +1234,59 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">69295 (21.3%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/selective-serotonin-reuptake-inhibitors/1">https://github.com/rw251/.../medications/selective-serotonin-reuptake-inhibitors/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">556431 (22%)</td>
+<td style="text-align:right">556431 (22%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">52604 (26.1%)</td>
+<td style="text-align:right">52604 (26.1%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">77183 (23%)</td>
+<td style="text-align:right">77183 (23%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/selective-serotonin-reuptake-inhibitors/1">https://github.com/rw251/.../medications/selective-serotonin-reuptake-inhibitors/1</a></p>
 <h3>Tricyclic (TCA)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amitriptyline
+-- Amitriptyline (Lentizol)
 -- Amitriptyline hydrochloride
 -- Amitriptyline hydrochloride/ Perphenazine
 -- Butriptyline Hydrochloride
--- Clomipramine
+-- Clomipramine (Anafranil)
 -- Clomipramine hydrochloride
 -- Desipramine
 -- Dosulepin
 -- Dosulepin hydrochloride
--- Doxepin
+-- Doxepin (Sinequan/Sinepin/Xepin)
 -- Doxepin hydrochloride
--- Imipramine
+-- Imipramine (Tofranil)
 -- Imipramine hydrochloride
 -- Iprindole
--- Lofepramine
+-- Lofepramine (Feprapax/Lomont/Gamanil)
 -- Lofepramine hydrochloride
--- Nortriptyline
+-- Nortriptyline (Allegron/Motival/Motipress)
 -- Nortriptyline hydrochloride
--- Protriptyline
+-- Protriptyline (Vivactil)
 -- Protriptyline hydrochloride
--- Trimipramine
+-- Trimipramine (Surmontil)
 -- Trimipramine maleate</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>14.1 - 17.8%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>14.3 - 17.3%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -994,24 +1320,43 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">45430 (13.9%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tricyclic-antidepressants/1">https://github.com/rw251/.../medications/tricyclic-antidepressants/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">362600 (14.3%)</td>
+<td style="text-align:right">362600 (14.3%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">34912 (17.3%)</td>
+<td style="text-align:right">34912 (17.3%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">50609 (15.1%)</td>
+<td style="text-align:right">50609 (15.1%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tricyclic-antidepressants/1">https://github.com/rw251/.../medications/tricyclic-antidepressants/1</a></p>
 <h3>Tetracyclic (TeCA)</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amoxapine
--- Maprotiline
+-- Amoxapine (Asendis/Defanyl)
+-- Maprotiline (Ludiomil)
 -- Maprotiline hydrochloride
 -- Mianserin
 -- Mianserin hydrochloride
--- Mirtazapine</p>
+-- Mirtazapine (Zispin)</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>5.4 - 8.3%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>6.3% - 8.4%</code> suggests that this code set is reasonably defined, but with a higher prevalence in TPP practices.</p>
 <table>
 <thead>
 <tr>
@@ -1045,27 +1390,45 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">17687 (5.4%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tetracyclic/1">https://github.com/rw251/.../medications/tetracyclic/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">174811 (6.91%)</td>
+<td style="text-align:right">174811 (6.91%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">16998 (8.42%)</td>
+<td style="text-align:right">16998 (8.42%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">21158 (6.31%)</td>
+<td style="text-align:right">21158 (6.31%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tetracyclic/1">https://github.com/rw251/.../medications/tetracyclic/1</a></p>
 <h3>Other antidepressants</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Agomelatine
--- Ascorbic Acid/Tryptophan/Pyridoxine Hydrochloride
--- Bupropion hydrochloride
--- Bupropion hydrochloride/Naltrexone hydrochloride
--- Esketamine hydrochloride
--- Ketamine
--- Ketamine hydrochloride
--- Oxitriptan
--- Tryptophan</p>
+<p>This code set was created as the union of the following drugs as specified from the PI of RQ051:</p>
+<ul>
+<li>Agomelatine</li>
+<li>Bupropion</li>
+<li>Esketamine</li>
+<li>Ketamine</li>
+<li>Oxitriptan</li>
+<li>Tryptophan</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>1.3 - 1.9%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.73 - 0.85%</code> for EMIS and Vision practices suggests this is well defined. However TPP practices have a rate of <code>1.4%</code>, nearly double that of EMIS and Vision, suggesting extra prescribing in those practices. TPP has the smallest footprint in terms of patient numbers which may also be a contributing factor.</p>
 <table>
 <thead>
 <tr>
@@ -1099,29 +1462,50 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">4693 (1.4%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-antidepressants/1">https://github.com/rw251/.../medications/other-antidepressants/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-08</td>
+<td>EMIS</td>
+<td>2516912</td>
+<td style="text-align:right">18340 (0.729%)</td>
+<td style="text-align:right">18340 (0.729%)</td>
+</tr>
+<tr>
+<td>2024-05-08</td>
+<td>TPP</td>
+<td>200013</td>
+<td style="text-align:right">2779 (1.39%)</td>
+<td style="text-align:right">2779 (1.39%)</td>
+</tr>
+<tr>
+<td>2024-05-08</td>
+<td>Vision</td>
+<td>334384</td>
+<td style="text-align:right">2856 (0.854%)</td>
+<td style="text-align:right">2856 (0.854%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-08</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-antidepressants/1">https://github.com/rw251/.../medications/other-antidepressants/1</a></p>
 <h3>Barbituates</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amobarbital
--- Amobarbital/Secobarbital
--- Barbital
--- Butobarbital
--- Cyclobarbital
--- Methylphenobarbital
--- Pentobarbital
--- Phenobarbital
--- Primidone
--- Secobarbital
--- Thiopental</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Amobarbital</li>
+<li>Amobarbital/Secobarbital</li>
+<li>Barbital</li>
+<li>Butobarbital</li>
+<li>Cyclobarbital</li>
+<li>Methylphenobarbital</li>
+<li>Pentobarbital</li>
+<li>Phenobarbital</li>
+<li>Primidone</li>
+<li>Secobarbital</li>
+<li>Thiopental</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.09 - 0.15%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.11 - 0.14%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1155,38 +1539,59 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">314 (0.09%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/barbituates/1">https://github.com/rw251/.../medications/barbituates/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">2737 (0.108%)</td>
+<td style="text-align:right">2737 (0.108%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">283 (0.14%)</td>
+<td style="text-align:right">283 (0.14%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">366 (0.109%)</td>
+<td style="text-align:right">366 (0.109%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-02</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/barbituates/1">https://github.com/rw251/.../medications/barbituates/1</a></p>
 <h3>Benzodiazepine</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Alprazolam
--- Bromazepam
--- Chlordiazepoxide
--- Clobazam
--- Clonazepam
--- Clorazepate
--- Diazepam
--- Flunitrazepam
--- Flurazepam
--- Ketazolam
--- Loprazolam
--- Lorazepam
--- Lormetazepam
--- Medazepam
--- Midazolam
--- Nitrazepam
--- Oxazepam
--- Prazepam
--- Temazepam
--- Triazolam</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Alprazolam (Xanax)</li>
+<li>Bromazepam (Lexotan)</li>
+<li>Chlordiazepoxide (librium/tropium/limbitrol/librax )</li>
+<li>Clobazam (frisium/perizam/tapclob/zacco)</li>
+<li>Clonazepam (rivotril/klonopin )</li>
+<li>Clorazepate (tranxene)</li>
+<li>Diazepam (valium/tensium/stesolid/solis/rectubes/alupram/rimapam/dialar/valclair/atensine/diazemuls/evacalm )</li>
+<li>Flunitrazepam (rohypnol)</li>
+<li>Flurazepam (dalmane/paxane )</li>
+<li>Ketazolam (anxon)</li>
+<li>Loprazolam (dormonoct)</li>
+<li>Lorazepam (ativan/almazine )</li>
+<li>Lormetazepam (noctamid)</li>
+<li>Medazepam (nobrium)</li>
+<li>Midazolam (hypnovel/buccolam/dormicum/miprosed/ozalin/epistatus)</li>
+<li>Nitrazepam (unisomnia/surem/somnite/remnos/noctesed/nitrados/mogadon )</li>
+<li>Oxazepam (oxanid)</li>
+<li>Prazepam (centrax)</li>
+<li>Temazepam (normison/euhypnos )</li>
+<li>Triazolam (halcion)</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>10.4 - 11.7%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>10.4 - 11.6%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1220,21 +1625,42 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">36313 (11.1%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/benzodiazepines/2">https://github.com/rw251/.../medications/benzodiazepines/2</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-07</td>
+<td>EMIS</td>
+<td>2516912</td>
+<td style="text-align:right">261145 (10.4%)</td>
+<td style="text-align:right">261145 (10.4%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>TPP</td>
+<td>200013</td>
+<td style="text-align:right">23182 (11.6%)</td>
+<td style="text-align:right">23182 (11.6%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>Vision</td>
+<td>334384</td>
+<td style="text-align:right">37288 (11.2%)</td>
+<td style="text-align:right">37288 (11.2%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-07</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/benzodiazepines/2">https://github.com/rw251/.../medications/benzodiazepines/2</a></p>
 <h3>Non-benzodiazepine benzodiazepine receptor agonist (NBBRA)</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Zaleplon
--- Zolpidem
--- Zopiclone</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Zaleplon (Sonata)</li>
+<li>Zolpidem (Stilnoct)</li>
+<li>Zopiclone (Zimovane/Zileze)</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>7.2 - 9.4%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>7.4 - 9.2%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1268,35 +1694,53 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">23547 (7.2%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1">https://github.com/rw251/.../medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">211298 (8.35%)</td>
+<td style="text-align:right">211298 (8.35%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">18524 (9.18%)</td>
+<td style="text-align:right">18524 (9.18%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">24765 (7.38%)</td>
+<td style="text-align:right">24765 (7.38%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1">https://github.com/rw251/.../medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1</a></p>
 <h3>Other anxiolytics and hypnotics</h3>
 <p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Alimemazine
--- Buspirone
--- Chloral
+-- Alimemazine (Alfresed/Itzenal/Timeprazine/Vallergan)
+-- Buspirone (Buspar)
+-- Chloral (Amfecloral/Cloral betaine/Chlorobutanol/Eludril?/Frador/Petrichloral/Soothake?/Triclofos/Welldorm)
 -- Chlormezanone
--- Clomethiazole
+-- Clomethiazole (Heminevrin)
 -- Dichloralphenazone
 -- Diphenhydramine
--- Hydroxyzine
--- Melatonin
+-- Hydroxyzine (Atarax/Ucerax)
+-- Melatonin (Adaflex/Agomelatine?/Ceyesto/Circadin/Ramelteon/Slenyto/Syncrodin/S.Gard/Tasimelteon?/Valdoxan?)
 -- Meprobamate
 -- Methyprylone
--- Potassium bromide
+-- Potassium bromide (Dibro-Be)
 -- Potassium bromide/chloral
--- Promethazine
+-- Promethazine (Avomine/Night Nurse/Pamergan/Phenergan/Sominex/Tixylix/Vertigon/Ziz)
 -- Sodium hydroxybutyrate
--- Sodium oxybate
--- Triclofos</p>
+-- Sodium oxybate (Xyrem)</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>5.3 - 7.0%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>6.7 - 9.0%</code> suggests that this code set is well defined, but with a higher prevalence in Vision practices.</p>
 <table>
 <thead>
 <tr>
@@ -1330,81 +1774,76 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">22896 (7.0%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-anxiolytics-and-hypnotics/1">https://github.com/rw251/.../medications/other-anxiolytics-and-hypnotics/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-01</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">185302 (7.32%)</td>
+<td style="text-align:right">185302 (7.32%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">13455 (6.67%)</td>
+<td style="text-align:right">13455 (6.67%)</td>
+</tr>
+<tr>
+<td>2024-05-01</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">30439 (9.08%)</td>
+<td style="text-align:right">30439 (9.08%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-anxiolytics-and-hypnotics/1">https://github.com/rw251/.../medications/other-anxiolytics-and-hypnotics/1</a></p>
 <h3>Antipsychotics</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amisulpride
--- Amitriptyline hydrochloride/Perphenazine
--- Aripiprazole
--- Asenapine maleate
--- Benperidol
--- Cariprazine hydrochloride
--- Chlorpromazine
--- Chlorpromazine embonate
--- Chlorpromazine hydrochloride
--- Chlorprothixene
--- Clozapine
--- Droperidol
--- Flupentixol
--- Flupentixol decanoate
--- Flupentixol dihydrochloride
--- Fluphenazine
--- Fluphenazine decanoate
--- Fluphenazine Enantate
--- Fluphenazine hydrochloride
--- Fluphenazine hydrochloride/Nortriptyline hydrochloride
--- Fluspirilene
--- Haloperidol
--- Haloperidol decanoate
--- Isopropamide Iodide/Trifluoperazine Hydrochloride
--- Levomepromazine hydrochloride
--- Levomepromazine maleate
--- Loxapine
--- Loxapine succinate
--- Lurasidone hydrochloride
--- Melperone hydrochloride
--- Nortriptyline hydrochloride/Fluphenazine hydrochloride
--- Olanzapine
--- Olanzapine embonate monohydrate
--- Oxypertine
--- Paliperidone
--- Paliperidone palmitate
--- Pericyazine
--- Perphenazine
--- Pimozide
--- Pipotiazine palmitate
--- Prochlorperazine
--- Prochlorperazine maleate
--- Prochlorperazine mesilate
--- Promazine
--- Promazine hydrochloride
--- Quetiapine
--- Quetiapine fumarate
--- Remoxipride Hydrochloride Monohydrate
--- Risperidone
--- Sertindole
--- Sulpiride
--- Thioridazine
--- Thioridazine hydrochloride
--- Trifluoperazine
--- Trifluoperazine hydrochloride
--- Trifluoperazine Hydrochloride/Tranylcypromine Sulphate
--- Trifluperidol
--- Ziprasidone hydrochloride
--- Zotepine
--- Zuclopenthixol
--- Zuclopenthixol acetate
--- Zuclopenthixol decanoate
--- Zuclopenthixol dihydrochloride</p>
+<p>Code set created using the following list from the PI of RQ051. Each component drug has its own code set and this is the union of the following:</p>
+<ul>
+<li>Amisulpride (Solian)</li>
+<li>Aripiprazole (Ablify/Arpoya)</li>
+<li>Asenapine maleate (Sycrest)</li>
+<li>Benperidol (Anquil/Benquil)</li>
+<li>Cariprazine hydrochloride (Reagila)</li>
+<li>Chlorpromazine (Chloractil/Chlorazin/Dozine/Largactil)</li>
+<li>Chlorprothixene (Taractan/Truxal)</li>
+<li>Clozapine (Clozaril/Denzapine/Zaponex)</li>
+<li>Droperidol (Droleptan/Thalamonal/Xomolix)</li>
+<li>Flupentixol (Depixol/Fluanxol/Flupenthixol/Psytixol)</li>
+<li>Fluphenazine (Decazate/Modecate/Motipress/Moditen/Motival)</li>
+<li>Fluspirilene (Imap/Redeptin)</li>
+<li>Haloperidol (Dozic/Fortunan/Haldol/Halkid/Kentace/Serenace)</li>
+<li>Levomepromazine (Levinan/Levorol/Methotrimeprazine/Nozinan/Veractil)</li>
+<li>Loxapine (Adasuve/Loxapac)</li>
+<li>Lurasidone hydrochloride (Latuda)</li>
+<li>Melperone hydrochloride (Melperon-ratiopharm)</li>
+<li>Olanzapine (Arkolamyl/Xyquila /Zalasta/Zypadhera/Zyprexa)</li>
+<li>Oxypertine (Integrin)</li>
+<li>Paliperidone (Byannli/Invega/Trevicta/Xeplion)</li>
+<li>Pericyazine</li>
+<li>Perphenazine</li>
+<li>Pimozide</li>
+<li>Pipotiazine palmitate</li>
+<li>Prochlorperazine</li>
+<li>Promazine</li>
+<li>Quetiapine</li>
+<li>Remoxipride Hydrochloride Monohydrate</li>
+<li>Risperidone</li>
+<li>Sertindole</li>
+<li>Sulpiride</li>
+<li>Thioridazine</li>
+<li>Trifluoperazine</li>
+<li>Trifluperidol</li>
+<li>Ziprasidone hydrochloride</li>
+<li>Zotepine</li>
+<li>Zuclopenthixol</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>12.9 - 15.7%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>13% - 15.7%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1438,23 +1877,44 @@ Here is a log for this code set. The prevalence range (1.10% - 1.90%)</p>
 <td style="text-align:right">45098 (13.8%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/antipsychotics/2">https://github.com/rw251/.../medications/antipsychotics/2</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-07</td>
+<td>EMIS</td>
+<td>2516912</td>
+<td style="text-align:right">326391 (13%)</td>
+<td style="text-align:right">326391 (13%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>TPP</td>
+<td>200013</td>
+<td style="text-align:right">31318 (15.7%)</td>
+<td style="text-align:right">31318 (15.7%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>Vision</td>
+<td>334384</td>
+<td style="text-align:right">46957 (14%)</td>
+<td style="text-align:right">46957 (14%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-07</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/antipsychotics/2">https://github.com/rw251/.../medications/antipsychotics/2</a></p>
 <h3>Antoconvusants</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
-Carbamazepine
-Lamotrigine
-Sodium valproate
-Valproate semisodium
-Valproic acid</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Carbamazepine</li>
+<li>Lamotrigine</li>
+<li>Sodium valproate</li>
+<li>Valproate semisodium</li>
+<li>Valproic acid</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range from the code is <code>1.9% - 2.4%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range from the code is <code>1.9% - 2.1%</code> suggesting that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1487,12 +1947,38 @@ Valproic acid</p>
 <td style="text-align:right">6704 (2.1%)</td>
 <td style="text-align:right">6707 (2.1%)</td>
 </tr>
+<tr>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">48541 (1.92%)</td>
+<td style="text-align:right">48541 (1.92%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">4268 (2.11%)</td>
+<td style="text-align:right">4268 (2.11%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">7019 (2.09%)</td>
+<td style="text-align:right">7019 (2.09%)</td>
+</tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-02</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/anticonvulsants/1">https://github.com/rw251/.../medications/anticonvulsants/1</a></p>
 <h3>Lithium</h3>
+<p>Any code for a prescription of lithium. Taken from the NHS drug refsets.</p>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.11% - 0.15%</code> suggests the code set is well defined across systems, however the prevalence seems low and may need checking.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.11% - 0.15%</code> suggests the code set is well defined across systems, with a slightly lower prevalence in TPP practices.</p>
 <table>
 <thead>
 <tr>
@@ -1525,16 +2011,43 @@ Valproic acid</p>
 <td style="text-align:right">460 (0.14%)</td>
 <td style="text-align:right">460 (0.14%)</td>
 </tr>
+<tr>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">3678 (0.145%)</td>
+<td style="text-align:right">3678 (0.145%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">213 (0.106%)</td>
+<td style="text-align:right">213 (0.106%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">470 (0.14%)</td>
+<td style="text-align:right">470 (0.14%)</td>
+</tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
 <p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/lithium/1">https://github.com/rw251/.../medications/lithium/1</a></p>
 <h3>Off label mood stabilisers</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Gabapentin
--- Oxcarbazepine
--- Topiramate</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Gabapentin (Neurontin)</li>
+<li>Oxcarbazepine (Trileptal)</li>
+<li>Topiramate (Topamax)</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>5.9 - 6.7%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>6.1 - 6.6%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1568,30 +2081,48 @@ Valproic acid</p>
 <td style="text-align:right">21084 (6.5%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/off-label-mood-stabilisers/1">https://github.com/rw251/.../medications/off-label-mood-stabilisers/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-02</td>
+<td>EMIS</td>
+<td>2530927</td>
+<td style="text-align:right">153657 (6.07%)</td>
+<td style="text-align:right">153657 (6.07%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>TPP</td>
+<td>201816</td>
+<td style="text-align:right">13147 (6.51%)</td>
+<td style="text-align:right">13147 (6.51%)</td>
+</tr>
+<tr>
+<td>2024-05-02</td>
+<td>Vision</td>
+<td>335411</td>
+<td style="text-align:right">22262 (6.64%)</td>
+<td style="text-align:right">22262 (6.64%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-01</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/off-label-mood-stabilisers/1">https://github.com/rw251/.../medications/off-label-mood-stabilisers/1</a></p>
 <h3>Attention deficit hyperactivity disorder medications</h3>
-<p>This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amfetamine/Dexamfetamine
--- Amfetamine/Dexamfetamine Sulphate
--- Atomoxetine hydrochloride
--- Dexamfetamine Sulphate
--- Dexedrine
--- Dexmethylphenidate hydrochloride
--- Guanfacine hydrochloride
--- Lisdexamfetamine dimesylate
--- Methylphenidate hydrochloride
--- Modafinil
--- Pitolisant hydrochloride
--- Ritalin</p>
+<p>This code set was created from getset.ga, using the following list from the PI of RQ051:</p>
+<ul>
+<li>Amfetamine/Dexamfetamine (Adderall/Durophet)</li>
+<li>Atomoxetine hydrochloride (Atomaid/Strattera)</li>
+<li>Dexamfetamine Sulphate (Amfexa/Dexamphetamine/Dexedrine/Dextroamphetamine)</li>
+<li>Dexmethylphenidate hydrochloride (Focalin)</li>
+<li>Guanfacine hydrochloride (Intuniv/Tenex)</li>
+<li>Lisdexamfetamine dimesylate (Elvanse/Vyvanse)</li>
+<li>Methylphenidate hydrochloride (Affenid/Concerta/Delmosart/Equasym/Matoride/Medikinet/Meflynate/Metyrol/Ritalin/Tranquilyn/Xaggitin/Xenidate)</li>
+<li>Modafinil (Provigil)</li>
+<li>Pitolisant hydrochloride (Wakix)</li>
+</ul>
 <h4>Prevalence log</h4>
-<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.5 - 0.7%</code> suggests that this code set is well defined.</p>
+<p>By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range <code>0.7% - 0.9%</code> suggests that this code set is well defined.</p>
 <table>
 <thead>
 <tr>
@@ -1625,13 +2156,32 @@ Valproic acid</p>
 <td style="text-align:right">2229 (0.7%)</td>
 </tr>
 <tr>
-<td>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/attention-deficit-hyperactivity-disorder-medications/1">https://github.com/rw251/.../medications/attention-deficit-hyperactivity-disorder-medications/1</a></td>
-<td></td>
-<td></td>
-<td style="text-align:right"></td>
-<td style="text-align:right"></td>
+<td>2024-05-07</td>
+<td>EMIS</td>
+<td>2516912</td>
+<td style="text-align:right">18135 (0.721%)</td>
+<td style="text-align:right">18135 (0.721%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>TPP</td>
+<td>200013</td>
+<td style="text-align:right">1444 (0.722%)</td>
+<td style="text-align:right">1444 (0.722%)</td>
+</tr>
+<tr>
+<td>2024-05-07</td>
+<td>Vision</td>
+<td>334384</td>
+<td style="text-align:right">3158 (0.944%)</td>
+<td style="text-align:right">3158 (0.944%)</td>
 </tr>
 </tbody>
 </table>
+<h4>Audit log</h4>
+<ul>
+<li>Find_missing_codes last run 2024-05-07</li>
+</ul>
+<p>LINK: <a href="https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/attention-deficit-hyperactivity-disorder-medications/1">https://github.com/rw251/.../medications/attention-deficit-hyperactivity-disorder-medications/1</a></p>
 <h1>Clinical code sets</h1>
 <p>All code sets required for this analysis are available here: <a href="https://github.com/rw251/gm-idcr/tree/master/projects/051%20-%20Webb/clinical-code-sets.csv">https://github.com/rw251/.../051 - Webb/clinical-code-sets.csv</a>. Individual lists for each concept can also be found by using the links above.</p>

--- a/projects/051 - Webb/README.md
+++ b/projects/051 - Webb/README.md
@@ -248,18 +248,24 @@ Further details for each code set can be found below.
 
 ### Anxiety
 
-Any code indicating a diagnosis of anxiety or other somatoform disorder.
+Any code indicating a diagnosis of anxiety or other somatoform disorder. Developed from SNOMED searches and the opencodelist code set: https://www.opencodelists.org/codelist/opensafely/anxiety-disorders/6aef605a/.
 #### Prevalence log
 
 By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.
 
-The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range `18.23% - 18.77%` suggests that this code set is well defined.
+The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range `21.3% - 22%` suggests that this code set is well defined.
 
-| Date        | Practice system | Population | Patients from ID | Patient from code |
-| ----------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-05-16  | EMIS            | 2662570    |  499713 (18.77%) |   502416 (18.87%) |
-| 2022-05-16  | TPP             | 212696     |   38757 (18.22%) |    38769 (18.23%) |
-| 2022-05-16  | Vision          | 342344     |   65130 (19.02%) |    64271 (18.77%)) |
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------: | ----------------: |
+| 2022-05-16 | EMIS            | 2662570    |  499713 (18.77%) |   502416 (18.87%) |
+| 2022-05-16 | TPP             | 212696     |   38757 (18.22%) |    38769 (18.23%) |
+| 2022-05-16 | Vision          | 342344     |   65130 (19.02%) |    64271 (18.77%) |
+| 2024-04-30 | EMIS            | 2530927    |   766186 (30.3%) |    549512 (21.7%) |
+| 2024-04-30 | TPP             | 201816     |      46335 (23%) |     42913 (21.3%) |
+| 2024-04-30 | Vision          | 335411     |    77888 (23.2%) |       73817 (22%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
 
 LINK: [https://github.com/rw251/.../conditions/anxiety/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/anxiety/1)
 
@@ -268,17 +274,29 @@ LINK: [https://github.com/rw251/.../conditions/anxiety/1](https://github.com/rw2
 Code set for patients with a diagnosis of depression.
 
 Developed from www.opencodelists.org
+
+- No "affective disorder" codes unless mention of depression e.g. 191632009: Bipolar affective disorder, currently depressed, severe, with psychosis (disorder)
+- Seasonal affective disorder included as that is a depressive condition
+- Includes non-diagnosis codes such as monitoring invites
+- Codes indicating grief from bereavement or other life events are included on the grounds that if they are coded in a person's record they are likely clinically important
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, 
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system,
 we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.
-Prevalence range: 21.09% - 22.83%
+The prevalence range `23% - 25%` suggests that this code set is well defined.
 
-|    Date    | Practice system |  Population | Patients from ID | Patient from code |
-| ---------- | ----------------| ------------| ---------------- | ----------------- |
-| 2022-05-12 |	EMIS	       |  2662570    |	553650 (20.79%) | 560060 (21.03%)   |
-| 2022-05-12 |	TPP	           |   212696    |   45884 (21.57%) |  45912 (21.59%)   |
-| 2022-05-12 |	Vision	       |   342344    |   75709 (22.11%) |  73277 (21.40%)   |
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------- | ----------------- |
+| 2022-05-12 | EMIS            | 2662570    | 553650 (20.79%)  | 560060 (21.03%)   |
+| 2022-05-12 | TPP             | 212696     | 45884 (21.57%)   | 45912 (21.59%)    |
+| 2022-05-12 | Vision          | 342344     | 75709 (22.11%)   | 73277 (21.40%)    |
+| 2024-01-19 | EMIS            | 2519438    | 676518 (26.9%)   | 572943 (22.7%)    |
+| 2024-01-19 | TPP             | 201469     | 51022 (25.3%)    | 50682 (25.2%)     |
+| 2024-01-19 | Vision          | 334528     | 80546 (24.1%)    | 78271 (23.4%)     |
+#### Audit log
+
+- Find_missing_codes last run 2024-01-17
+
 LINK: [https://github.com/rw251/.../conditions/depression/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/depression/1)
 
 ### Schizophrenia and Psychosis
@@ -288,14 +306,19 @@ Code set for patients with a diagnosis of psychosis or schizophrenia.
 Developed from www.opencodelists.org
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions.
-Here is a log for this code set. The prevalence range (1.10% - 1.90%)
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. The prevalence range `1% - 1.3%` suggests this is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------- | ----------------- |
 | 2021-06-16 | EMIS            | 2608685    | 46695 (1.79%)    | 46695 (1.79%)     |
 | 2021-06-16 | TPP             | 210985     | 28695 (1.10%)    | 28695 (1.10%)     |
 | 2021-06-16 | Vision          | 335010     | 49565 (1.90%)    | 49565 (1.90%)     |
+| 2024-04-30 | EMIS            | 2530927    | 42592 (1.68%)    | 25346 (1%)        |
+| 2024-04-30 | TPP             | 201816     | 2709 (1.34%)     | 2692 (1.33%)      |
+| 2024-04-30 | Vision          | 335411     | 5057 (1.51%)     | 3253 (0.97%)      |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
 
 LINK: [https://github.com/rw251/.../conditions/schizophrenia-psychosis/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/schizophrenia-psychosis/1)
 
@@ -303,33 +326,47 @@ LINK: [https://github.com/rw251/.../conditions/schizophrenia-psychosis/1](https:
 
 Code set for patients with a diagnosis of bipolar.
 
-Developed from www.opencodelists.org
+Developed from www.opencodelists.org and the NHS PCD refsets.
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. Prevalence range: 0.28% - 0.54%
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. Prevalence range: `0.28% - 0.31%` suggests this is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------- | ----------------- |
 | 2021-06-30 | EMIS            | 2608685    | 14087 (0.54%)    | 14087 (0.54%)     |
 | 2021-06-30 | TPP             | 210985     | 591 (0.28%)      | 591 (0.28%)       |
 | 2021-06-30 | Vision          | 335010     | 1608 (0.48%)     | 1608 (0.48%)      |
+| 2024-04-30 | EMIS            | 2530927    | 322887 (12.8%)   | 7791 (0.308%)     |
+| 2024-04-30 | TPP             | 201816     | 1096 (0.543%)    | 570 (0.282%)      |
+| 2024-04-30 | Vision          | 335411     | 8076 (2.41%)     | 972 (0.29%)       |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
 
 LINK: [https://github.com/rw251/.../conditions/bipolar/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/bipolar/1)
 
 ### Eating disorders
 
-Any code indicating a diagnosis of anorexia or bulimia or similar eating disorders.
+Any code indicating a diagnosis of anorexia or bulimia or similar eating disorders. SNOMED codes from the NHS PCD refset.
+
+- Does not include "loss of appetite codes" unless there is an indication that it is a symptom of anorexia.
 #### Prevalence log
 
 By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.
 
-The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range `0.42% - 0.84%` suggests that this code set is well defined.
+The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary. The prevalence range `0.68% - 0.85%` suggests that this code set is well defined.
 
-| Date        | Practice system | Population | Patients from ID | Patient from code |
-| ----------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-05-06  | EMIS            | 2662112    |    22407 (0.84%) |     22407 (0.84%) |
-| 2022-05-06  | TPP             | 212726     |      885 (0.42%) |       885 (0.42%) |
-| 2022-05-06  | Vision          | 342310     |     1999 (0.58%) |      1935 (0.57%) |
+| Date       | Practice system | Population | Patients from ID | Patient from code |
+| ---------- | --------------- | ---------- | ---------------: | ----------------: |
+| 2022-05-06 | EMIS            | 2662112    |    22407 (0.84%) |     22407 (0.84%) |
+| 2022-05-06 | TPP             | 212726     |      885 (0.42%) |       885 (0.42%) |
+| 2022-05-06 | Vision          | 342310     |     1999 (0.58%) |      1935 (0.57%) |
+| 2024-04-30 | EMIS            | 2530927    |    34267 (1.35%) |    21377 (0.845%) |
+| 2024-04-30 | TPP             | 201816     |     3067 (1.52%) |     1362 (0.675%) |
+| 2024-04-30 | Vision          | 335411     |     3719 (1.11%) |     2472 (0.737%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
 
 LINK: [https://github.com/rw251/.../conditions/eating-disorders/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/eating-disorders/1)
 
@@ -337,519 +374,629 @@ LINK: [https://github.com/rw251/.../conditions/eating-disorders/1](https://githu
 
 Defined as any episode of self-harm (except accidental) or attempted suicide
 
-Readv2 code set supplied by the PI for RQ-029(Steeg) 
+Readv2 code set supplied by the PI for RQ-029(Steeg)
 
 CTV3 and SNOMED code sets created using the Reference_Coding table in the GMCR, based on the Readv2 code set.
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set.
-
-The discrepancy between the patients counted when using the IDs vs using the clinical codes is due to these being new codes which haven't all filtered through to the main Graphnet dictionary.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. The prevalence range `3.83% - 4.17%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
 | 2021-04-14 | EMIS            | 2603707    |   102353 (3.97%) |     95004 (3.65%) |
 | 2021-04-14 | TPP             | 210613     |     7591 (3.61%) |      7257 (3.45%) |
 | 2021-04-14 | Vision          | 333786     |    12661 (3.79%) |     11975 (3.59%) |
+| 2024-04-30 | EMIS            | 2530927    |   105617 (4.17%) |    105491 (4.17%) |
+| 2024-04-30 | TPP             | 201816     |     8865 (4.39%) |         8072 (4%) |
+| 2024-04-30 | Vision          | 335411     |    12867 (3.84%) |     12836 (3.83%) |
+
 LINK: [https://github.com/rw251/.../patient/selfharm-episodes/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/patient/selfharm-episodes/1)
 
-### Attention deficit hyperactivity disorder 
+### Attention deficit hyperactivity disorder
 
 This code set was created from getset.ga.
+
+- Includes codes suggesting ADHD such as monitoring letters and annual reviews
+- Does not include ADHD assessment scales
+- Includes attention deficit disorder (i.e. without hyperactivity). This might not be what you want.
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.70 - 0.78%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `1.08 - 1.39%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-27 | EMIS            |    2449912 |    17633 (0.71%) |     17132 (0.70%) |
-| 2022-09-27 | TPP             |     198140 |     1474 (0.74%) |       1555(0.78%) |
-| 2022-09-27 | Vision          |     325784 |     2966 (0.91%) |       2457(0.75%) |
+| 2024-01-19 | EMIS            | 2519438    |    25644 (1.02%) |     25648 (1.02%) |
+| 2024-01-19 | TPP             | 201469     |     2059 (1.02%) |      2066 (1.03%) |
+| 2024-01-19 | Vision          | 334528     |     4394 (1.31%) |      4377 (1.31%) |
+| 2024-04-30 | EMIS            | 2530927    |    27454 (1.08%) |     27454 (1.08%) |
+| 2024-04-30 | TPP             | 201816     |     2147 (1.06%) |      2153 (1.07%) |
+| 2024-04-30 | Vision          | 335411     |     4674 (1.39%) |      4657 (1.39%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
+
 LINK: [https://github.com/rw251/.../conditions/attention-deficit-hyperactivity-disorder/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/attention-deficit-hyperactivity-disorder/1)
 
 ### Autism spectrum disorder
 
 This code set was created from getset.ga.
+
+- Includes "suspected autism" codes. This might not be what you want.
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.80 - 0.89%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `1.17 - 1.28%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-27 | EMIS            |    2449912 |    21708 (0.88%) |     21831 (0.89%) |
-| 2022-09-27 | TPP             |     198140 |     1575 (0.79%) |      1727 (0.87%) |
-| 2022-09-27 | Vision          |     325784 |     2769 (0.84%) |      2614 (0.80%) |
+| 2022-09-27 | EMIS            | 2449912    |    21708 (0.88%) |     21831 (0.89%) |
+| 2022-09-27 | TPP             | 198140     |     1575 (0.79%) |      1727 (0.87%) |
+| 2022-09-27 | Vision          | 325784     |     2769 (0.84%) |      2614 (0.80%) |
+| 2024-01-19 | EMIS            | 2519438    |    30794 (1.22%) |     30797 (1.22%) |
+| 2024-01-19 | TPP             | 201469     |     2239 (1.11%) |      2239 (1.11%) |
+| 2024-01-19 | Vision          | 334528     |     3851 (1.15%) |      3840 (1.15%) |
+| 2024-04-30 | EMIS            | 2530927    |    32491 (1.28%) |     32491 (1.28%) |
+| 2024-04-30 | TPP             | 201816     |     2359 (1.17%) |      2359 (1.17%) |
+| 2024-04-30 | Vision          | 335411     |     4183 (1.25%) |      4171 (1.24%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-04-30
+
 LINK: [https://github.com/rw251/.../conditions/autism-spectrum-disorder/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/conditions/autism-spectrum-disorder/1)
 
-### Monoamine Axidase Inhibitors (MAOI) 
+### Monoamine Axidase Inhibitors (MAOI)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Iproniazid
--- Isocarboxazid
--- Moclobemide
--- Phenelzine sulfate
--- Selegiline hydrochloride
--- Tranylcypromine sulfate
--- Trifluoperazine Hydrochloride/Tranylcypromine Sulphate
 
+- Iproniazid (marsilid)
+- Isocarboxazid (marplan)
+- Moclobemide (Manerix)
+- Phenelzine sulfate (Nardil)
+- Selegiline hydrochloride (Centrapryl/Eldepryl/Stilline/Vivapryl/Zelapar)
+- Tranylcypromine sulfate (parnate)
+- Trifluoperazine Hydrochloride/Tranylcypromine Sulphate (parstelin)
 #### Prevalence log
 
 By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.03 - 0.05%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-05-09 | EMIS            |  2450268   |      941 (0.04%) |       941 (0.04%) |
-| 2022-05-09 | TPP             |  198118    |      102 (0.05%) |       104 (0.05%) |
-| 2022-05-09 | Vision          |  325609    |      107 (0.03%) |       107 (0.03%) |
+| 2022-05-09 | EMIS            | 2450268    |      941 (0.04%) |       941 (0.04%) |
+| 2022-05-09 | TPP             | 198118     |      102 (0.05%) |       104 (0.05%) |
+| 2022-05-09 | Vision          | 325609     |      107 (0.03%) |       107 (0.03%) |
+| 2024-05-07 | EMIS            | 2516912    |    893 (0.0355%) |     893 (0.0355%) |
+| 2024-05-07 | TPP             | 200013     |      94 (0.047%) |       94 (0.047%) |
+| 2024-05-07 | Vision          | 334384     |    114 (0.0341%) |     114 (0.0341%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-07
+
 LINK: [https://github.com/rw251/.../medications/monoamine-oxidase-inhibitor/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/monoamine-oxidase-inhibitor/1)
 
-### Norepinephrine Reuptake Inhibitors (NRI)  
+### Norepinephrine Reuptake Inhibitors (NRI)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Atomoxetine hydrochloride
--- Reboxetine
--- Viloxazine Hydrochloride
 
+- Atomoxetine hydrochloride (Strattera/Atomaid)
+- Reboxetine (Edronax)
+- Viloxazine Hydrochloride (Vivalan)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.14 - 0.17%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.15 - 0.21%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-05 | EMIS            |    2450268 |     3431 (0.14%) |      3435 (0.14%) |
-| 2022-09-05 | TPP             |     198118 |      333 (0.17%) |       350 (0.17%) |
-| 2022-09-05 | Vision          |     325609 |      534 (0.16%) |       534 (0.16%) |
+| 2022-09-05 | EMIS            | 2450268    |     3431 (0.14%) |      3435 (0.14%) |
+| 2022-09-05 | TPP             | 198118     |      333 (0.17%) |       350 (0.17%) |
+| 2022-09-05 | Vision          | 325609     |      534 (0.16%) |       534 (0.16%) |
+| 2024-05-02 | EMIS            | 2530927    |    3906 (0.154%) |     3906 (0.154%) |
+| 2024-05-02 | TPP             | 201816     |     381 (0.189%) |      381 (0.189%) |
+| 2024-05-02 | Vision          | 335411     |     687 (0.205%) |      687 (0.205%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/norepinephrine-reuptake-inhibitors/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/norepinephrine-reuptake-inhibitors/1)
 
-### Serotonin Antagonist and Reuptake Inhibitors (SARI)  
+### Serotonin Antagonist and Reuptake Inhibitors (SARI)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Nefazodone
+-- Nefazodone (Dutonin)
 -- Nefazodone hydrochloride
--- Trazodone
+-- Trazodone (Molipaxin)
 -- Trazodone hydrochloride
-
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.6 - 1.2%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.7 - 1.2%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2450268 |     18764 (0.8%) |      18811 (0.8%) |
-| 2022-09-06 | TPP             |     198118 |      2241 (1.1%) |       2407 (1.2%) |
-| 2022-09-06 | Vision          |     325609 |      2032 (0.6%) |       2032 (0.6%) |
+| 2022-09-06 | EMIS            | 2450268    |     18764 (0.8%) |      18811 (0.8%) |
+| 2022-09-06 | TPP             | 198118     |      2241 (1.1%) |       2407 (1.2%) |
+| 2022-09-06 | Vision          | 325609     |      2032 (0.6%) |       2032 (0.6%) |
+| 2024-05-01 | EMIS            | 2530927    |   20341 (0.804%) |    20341 (0.804%) |
+| 2024-05-01 | TPP             | 201816     |     2384 (1.18%) |      2384 (1.18%) |
+| 2024-05-01 | Vision          | 335411     |     2448 (0.73%) |      2448 (0.73%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/serotonin-antagonist-reuptake-inhibitors/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-antagonist-reuptake-inhibitors/1)
 
-### Serotonin Modulator and Stimulator (SMS)  
+### Serotonin Modulator and Stimulator (SMS)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
 -- Vortioxetine hydrobromide
 
+_NB - at some point we should remove this code set as it is a duplicate of the vortioxetine code set._
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.001 - 0.003%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.058% - 0.076%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2447974 |      33 (0.001%) |       33 (0.001%) |
-| 2022-09-06 | TPP             |     198058 |       6 (0.003%) |        6 (0.001%) |
-| 2022-09-06 | Vision          |     325464 |       4 (0.001%) |        4 (0.001%) |
+| 2022-09-06 | EMIS            | 2447974    |      33 (0.001%) |       33 (0.001%) |
+| 2022-09-06 | TPP             | 198058     |       6 (0.003%) |        6 (0.001%) |
+| 2022-09-06 | Vision          | 325464     |       4 (0.001%) |        4 (0.001%) |
+| 2024-05-01 | EMIS            | 2530927    |   1474 (0.0582%) |    1474 (0.0582%) |
+| 2024-05-01 | TPP             | 201816     |    154 (0.0763%) |     154 (0.0763%) |
+| 2024-05-01 | Vision          | 335411     |    211 (0.0629%) |     211 (0.0629%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/serotonin-modulator-stimulator/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-modulator-stimulator/1)
 
-### Serotonin and Norepinephrine Reuptake Inhibitors (SNRI) 
+### Serotonin and Norepinephrine Reuptake Inhibitors (SNRI)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
 -- Desvenlafaxine
--- Duloxetine
--- Duloxetine hydrochloride
--- Venlafaxine hydrochloride
-
+-- Duloxetine (Cymbalta/Dutor/Depalta/Duciltia/Yentreve)
+-- Venlafaxine hydrochloride (Alventa/Apclaven/Amphero/Bonilux/Depefex/Efexor/Foraven/Majoven/Mentaven/Politid/Ranfaxine/Rodomel/Sunveniz/Tardcaps/Tifaxin/Tonpular/Trixat/Vaxalin/Venaxx/Vencarm/Venlablue/Venladex/Venlalic/Venlaneo/Venlasov/Vensir/Venzip/Vexarin/ViePax)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `3.57 - 4.35%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `4.0 - 4.4%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2447974 |    87145 (3.56%) |     87283 (3.57%) |
-| 2022-09-06 | TPP             |     198058 |     7861 (3.97%) |      8618 (4.35%) |
-| 2022-09-06 | Vision          |     325464 |    11698 (3.59%) |     11705 (3.59%) |
+| 2022-09-06 | EMIS            | 2447974    |    87145 (3.56%) |     87283 (3.57%) |
+| 2022-09-06 | TPP             | 198058     |     7861 (3.97%) |      8618 (4.35%) |
+| 2022-09-06 | Vision          | 325464     |    11698 (3.59%) |     11705 (3.59%) |
+| 2024-05-01 | EMIS            | 2530927    |   100387 (3.97%) |    100387 (3.97%) |
+| 2024-05-01 | TPP             | 201816     |      8873 (4.4%) |       8873 (4.4%) |
+| 2024-05-01 | Vision          | 335411     |    14357 (4.28%) |     14357 (4.28%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/serotonin-norepinephrine-reuptake-inhibitors/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/serotonin-norepinephrine-reuptake-inhibitors/1)
 
-### Selective Serotonin Reuptake Inhibitors (SSRI) 
+### Selective Serotonin Reuptake Inhibitors (SSRI)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Citalopram hydrobromide
+-- Citalopram hydrobromide (Cipramil)
 -- Citalopram hydrochloride
--- Escitalopram oxalate
--- Fluoxetine
+-- Escitalopram oxalate (Cipralex)
+-- Fluoxetine (Felicium/Olena/Oxactin/Prozep/Prozit/Ranflutin/Prozac)
 -- Fluoxetine hydrochloride
--- Fluvoxamine
+-- Fluvoxamine (Faverin)
 -- Fluvoxamine maleate
--- Paroxetine hydrochloride
--- Sertraline
+-- Paroxetine hydrochloride (Seroxat)
+-- Sertraline (Contulen/Lustral)
 -- Sertraline hydrochloride
-
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `21.1 - 26.6%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `22 - 26.1%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2448237 |   516631 (21.1%) |    517274 (21.1%) |
-| 2022-09-06 | TPP             |     198144 |    50341 (25.4%) |     52696 (26.6%) |
-| 2022-09-06 | Vision          |     325732 |    69233 (21.2%) |     69295 (21.3%) |
+| 2022-09-06 | EMIS            | 2448237    |   516631 (21.1%) |    517274 (21.1%) |
+| 2022-09-06 | TPP             | 198144     |    50341 (25.4%) |     52696 (26.6%) |
+| 2022-09-06 | Vision          | 325732     |    69233 (21.2%) |     69295 (21.3%) |
+| 2024-05-01 | EMIS            | 2530927    |     556431 (22%) |      556431 (22%) |
+| 2024-05-01 | TPP             | 201816     |    52604 (26.1%) |     52604 (26.1%) |
+| 2024-05-01 | Vision          | 335411     |      77183 (23%) |       77183 (23%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/selective-serotonin-reuptake-inhibitors/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/selective-serotonin-reuptake-inhibitors/1)
 
-### Tricyclic (TCA)  
+### Tricyclic (TCA)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amitriptyline
+-- Amitriptyline (Lentizol)
 -- Amitriptyline hydrochloride
 -- Amitriptyline hydrochloride/ Perphenazine
 -- Butriptyline Hydrochloride
--- Clomipramine
+-- Clomipramine (Anafranil)
 -- Clomipramine hydrochloride
 -- Desipramine
 -- Dosulepin
 -- Dosulepin hydrochloride
--- Doxepin
+-- Doxepin (Sinequan/Sinepin/Xepin)
 -- Doxepin hydrochloride
--- Imipramine
+-- Imipramine (Tofranil)
 -- Imipramine hydrochloride
 -- Iprindole
--- Lofepramine
+-- Lofepramine (Feprapax/Lomont/Gamanil)
 -- Lofepramine hydrochloride
--- Nortriptyline
+-- Nortriptyline (Allegron/Motival/Motipress)
 -- Nortriptyline hydrochloride
--- Protriptyline
+-- Protriptyline (Vivactil)
 -- Protriptyline hydrochloride
--- Trimipramine
+-- Trimipramine (Surmontil)
 -- Trimipramine maleate
-
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `14.1 - 17.8%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `14.3 - 17.3%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2448237 |   344328 (14.1%) |    344860 (14.1%) |
-| 2022-09-06 | TPP             |     198144 |    34122 (17.2%) |     35179 (17.8%) |
-| 2022-09-06 | Vision          |     325732 |    44883 (13.8%) |     45430 (13.9%) |
+| 2022-09-06 | EMIS            | 2448237    |   344328 (14.1%) |    344860 (14.1%) |
+| 2022-09-06 | TPP             | 198144     |    34122 (17.2%) |     35179 (17.8%) |
+| 2022-09-06 | Vision          | 325732     |    44883 (13.8%) |     45430 (13.9%) |
+| 2024-05-01 | EMIS            | 2530927    |   362600 (14.3%) |    362600 (14.3%) |
+| 2024-05-01 | TPP             | 201816     |    34912 (17.3%) |     34912 (17.3%) |
+| 2024-05-01 | Vision          | 335411     |    50609 (15.1%) |     50609 (15.1%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/tricyclic-antidepressants/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tricyclic-antidepressants/1)
 
-### Tetracyclic (TeCA)  
+### Tetracyclic (TeCA)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amoxapine
--- Maprotiline
+-- Amoxapine (Asendis/Defanyl)
+-- Maprotiline (Ludiomil)
 -- Maprotiline hydrochloride
 -- Mianserin
 -- Mianserin hydrochloride
--- Mirtazapine
-
+-- Mirtazapine (Zispin)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `5.4 - 8.3%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `6.3% - 8.4%` suggests that this code set is reasonably defined, but with a higher prevalence in TPP practices.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-06 | EMIS            |    2448237 |    155723 (6.4%) |     156219 (6.4%) |
-| 2022-09-06 | TPP             |     198144 |     15266 (7.7%) |      16477 (8.3%) |
-| 2022-09-06 | Vision          |     325732 |     17614 (5.4%) |      17687 (5.4%) |
+| 2022-09-06 | EMIS            | 2448237    |    155723 (6.4%) |     156219 (6.4%) |
+| 2022-09-06 | TPP             | 198144     |     15266 (7.7%) |      16477 (8.3%) |
+| 2022-09-06 | Vision          | 325732     |     17614 (5.4%) |      17687 (5.4%) |
+| 2024-05-01 | EMIS            | 2530927    |   174811 (6.91%) |    174811 (6.91%) |
+| 2024-05-01 | TPP             | 201816     |    16998 (8.42%) |     16998 (8.42%) |
+| 2024-05-01 | Vision          | 335411     |    21158 (6.31%) |     21158 (6.31%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/tetracyclic/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/tetracyclic/1)
 
-### Other antidepressants 
+### Other antidepressants
 
-This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Agomelatine
--- Ascorbic Acid/Tryptophan/Pyridoxine Hydrochloride
--- Bupropion hydrochloride
--- Bupropion hydrochloride/Naltrexone hydrochloride
--- Esketamine hydrochloride
--- Ketamine
--- Ketamine hydrochloride
--- Oxitriptan
--- Tryptophan
+This code set was created as the union of the following drugs as specified from the PI of RQ051:
 
+- Agomelatine
+- Bupropion
+- Esketamine
+- Ketamine
+- Oxitriptan
+- Tryptophan
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `1.3 - 1.9%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.73 - 0.85%` for EMIS and Vision practices suggests this is well defined. However TPP practices have a rate of `1.4%`, nearly double that of EMIS and Vision, suggesting extra prescribing in those practices. TPP has the smallest footprint in terms of patient numbers which may also be a contributing factor.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |     31860 (1.3%) |      31877 (1.3%) |
-| 2022-09-08 | TPP             |     198144 |      3840 (1.9%) |       3894 (1.9%) |
-| 2022-09-08 | Vision          |     325732 |      4692 (1.4%) |       4693 (1.4%) |
+| 2022-09-08 | EMIS            | 2448237    |     31860 (1.3%) |      31877 (1.3%) |
+| 2022-09-08 | TPP             | 198144     |      3840 (1.9%) |       3894 (1.9%) |
+| 2022-09-08 | Vision          | 325732     |      4692 (1.4%) |       4693 (1.4%) |
+| 2024-05-08 | EMIS            | 2516912    |   18340 (0.729%) |    18340 (0.729%) |
+| 2024-05-08 | TPP             | 200013     |     2779 (1.39%) |      2779 (1.39%) |
+| 2024-05-08 | Vision          | 334384     |    2856 (0.854%) |     2856 (0.854%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-08
+
 LINK: [https://github.com/rw251/.../medications/other-antidepressants/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-antidepressants/1)
 
 ### Barbituates
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amobarbital
--- Amobarbital/Secobarbital
--- Barbital
--- Butobarbital
--- Cyclobarbital
--- Methylphenobarbital
--- Pentobarbital
--- Phenobarbital
--- Primidone
--- Secobarbital
--- Thiopental
 
+- Amobarbital
+- Amobarbital/Secobarbital
+- Barbital
+- Butobarbital
+- Cyclobarbital
+- Methylphenobarbital
+- Pentobarbital
+- Phenobarbital
+- Primidone
+- Secobarbital
+- Thiopental
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.09 - 0.15%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.11 - 0.14%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |     2360 (0.09%) |      2365 (0.09%) |
-| 2022-09-08 | TPP             |     198144 |      270 (0.13%) |       304 (0.15%) |
-| 2022-09-08 | Vision          |     325732 |      314 (0.09%) |       314 (0.09%) |
+| 2022-09-08 | EMIS            | 2448237    |     2360 (0.09%) |      2365 (0.09%) |
+| 2022-09-08 | TPP             | 198144     |      270 (0.13%) |       304 (0.15%) |
+| 2022-09-08 | Vision          | 325732     |      314 (0.09%) |       314 (0.09%) |
+| 2024-05-02 | EMIS            | 2530927    |    2737 (0.108%) |     2737 (0.108%) |
+| 2024-05-02 | TPP             | 201816     |      283 (0.14%) |       283 (0.14%) |
+| 2024-05-02 | Vision          | 335411     |     366 (0.109%) |      366 (0.109%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-02
+
 LINK: [https://github.com/rw251/.../medications/barbituates/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/barbituates/1)
 
-### Benzodiazepine 
+### Benzodiazepine
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Alprazolam
--- Bromazepam
--- Chlordiazepoxide
--- Clobazam
--- Clonazepam
--- Clorazepate
--- Diazepam
--- Flunitrazepam
--- Flurazepam
--- Ketazolam
--- Loprazolam
--- Lorazepam
--- Lormetazepam
--- Medazepam
--- Midazolam
--- Nitrazepam
--- Oxazepam
--- Prazepam
--- Temazepam
--- Triazolam
 
+- Alprazolam (Xanax)
+- Bromazepam (Lexotan)
+- Chlordiazepoxide (librium/tropium/limbitrol/librax )
+- Clobazam (frisium/perizam/tapclob/zacco)
+- Clonazepam (rivotril/klonopin )
+- Clorazepate (tranxene)
+- Diazepam (valium/tensium/stesolid/solis/rectubes/alupram/rimapam/dialar/valclair/atensine/diazemuls/evacalm )
+- Flunitrazepam (rohypnol)
+- Flurazepam (dalmane/paxane )
+- Ketazolam (anxon)
+- Loprazolam (dormonoct)
+- Lorazepam (ativan/almazine )
+- Lormetazepam (noctamid)
+- Medazepam (nobrium)
+- Midazolam (hypnovel/buccolam/dormicum/miprosed/ozalin/epistatus)
+- Nitrazepam (unisomnia/surem/somnite/remnos/noctesed/nitrados/mogadon )
+- Oxazepam (oxanid)
+- Prazepam (centrax)
+- Temazepam (normison/euhypnos )
+- Triazolam (halcion)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `10.4 - 11.7%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `10.4 - 11.6%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-15 | EMIS            |    2448321 |   255338 (10.4%) |    255511 (10.4%) |
-| 2022-09-15 | TPP             |     198113 |    23190 (11.7%) |     23654 (11.9%) |
-| 2022-09-15 | Vision          |     325847 |    36301 (11.1%) |     36313 (11.1%) |
+| 2022-09-15 | EMIS            | 2448321    |   255338 (10.4%) |    255511 (10.4%) |
+| 2022-09-15 | TPP             | 198113     |    23190 (11.7%) |     23654 (11.9%) |
+| 2022-09-15 | Vision          | 325847     |    36301 (11.1%) |     36313 (11.1%) |
+| 2024-05-07 | EMIS            | 2516912    |   261145 (10.4%) |    261145 (10.4%) |
+| 2024-05-07 | TPP             | 200013     |    23182 (11.6%) |     23182 (11.6%) |
+| 2024-05-07 | Vision          | 334384     |    37288 (11.2%) |     37288 (11.2%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-07
+
 LINK: [https://github.com/rw251/.../medications/benzodiazepines/2](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/benzodiazepines/2)
 
-### Non-benzodiazepine benzodiazepine receptor agonist (NBBRA) 
+### Non-benzodiazepine benzodiazepine receptor agonist (NBBRA)
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Zaleplon
--- Zolpidem
--- Zopiclone
 
+- Zaleplon (Sonata)
+- Zolpidem (Stilnoct)
+- Zopiclone (Zimovane/Zileze)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `7.2 - 9.4%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `7.4 - 9.2%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |    205034 (8.4%) |     205190 (8.4%) |
-| 2022-09-08 | TPP             |     198144 |     18205 (9.2%) |      18552 (9.4%) |
-| 2022-09-08 | Vision          |     325732 |     23532 (7.2%) |      23547 (7.2%) |
+| 2022-09-08 | EMIS            | 2448237    |    205034 (8.4%) |     205190 (8.4%) |
+| 2022-09-08 | TPP             | 198144     |     18205 (9.2%) |      18552 (9.4%) |
+| 2022-09-08 | Vision          | 325732     |     23532 (7.2%) |      23547 (7.2%) |
+| 2024-05-02 | EMIS            | 2530927    |   211298 (8.35%) |    211298 (8.35%) |
+| 2024-05-02 | TPP             | 201816     |    18524 (9.18%) |     18524 (9.18%) |
+| 2024-05-02 | Vision          | 335411     |    24765 (7.38%) |     24765 (7.38%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/nonbenzodiazepine-benzodiazepine-receptor-agonist/1)
 
-### Other anxiolytics and hypnotics 
+### Other anxiolytics and hypnotics
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Alimemazine
--- Buspirone
--- Chloral
+-- Alimemazine (Alfresed/Itzenal/Timeprazine/Vallergan)
+-- Buspirone (Buspar)
+-- Chloral (Amfecloral/Cloral betaine/Chlorobutanol/Eludril?/Frador/Petrichloral/Soothake?/Triclofos/Welldorm)
 -- Chlormezanone
--- Clomethiazole
+-- Clomethiazole (Heminevrin)
 -- Dichloralphenazone
 -- Diphenhydramine
--- Hydroxyzine
--- Melatonin
+-- Hydroxyzine (Atarax/Ucerax)
+-- Melatonin (Adaflex/Agomelatine?/Ceyesto/Circadin/Ramelteon/Slenyto/Syncrodin/S.Gard/Tasimelteon?/Valdoxan?)
 -- Meprobamate
 -- Methyprylone
--- Potassium bromide
+-- Potassium bromide (Dibro-Be)
 -- Potassium bromide/chloral
--- Promethazine
+-- Promethazine (Avomine/Night Nurse/Pamergan/Phenergan/Sominex/Tixylix/Vertigon/Ziz)
 -- Sodium hydroxybutyrate
--- Sodium oxybate
--- Triclofos
-
+-- Sodium oxybate (Xyrem)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `5.3 - 7.0%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `6.7 - 9.0%` suggests that this code set is well defined, but with a higher prevalence in Vision practices.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |    136593 (5.6%) |     136694 (5.6%) |
-| 2022-09-08 | TPP             |     198144 |     10289 (5.2%) |      10575 (5.3%) |
-| 2022-09-08 | Vision          |     325732 |     22886 (7.0%) |      22896 (7.0%) |
+| 2022-09-08 | EMIS            | 2448237    |    136593 (5.6%) |     136694 (5.6%) |
+| 2022-09-08 | TPP             | 198144     |     10289 (5.2%) |      10575 (5.3%) |
+| 2022-09-08 | Vision          | 325732     |     22886 (7.0%) |      22896 (7.0%) |
+| 2024-05-01 | EMIS            | 2530927    |   185302 (7.32%) |    185302 (7.32%) |
+| 2024-05-01 | TPP             | 201816     |    13455 (6.67%) |     13455 (6.67%) |
+| 2024-05-01 | Vision          | 335411     |    30439 (9.08%) |     30439 (9.08%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/other-anxiolytics-and-hypnotics/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/other-anxiolytics-and-hypnotics/1)
 
-### Antipsychotics 
+### Antipsychotics
 
-This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amisulpride
--- Amitriptyline hydrochloride/Perphenazine
--- Aripiprazole
--- Asenapine maleate
--- Benperidol
--- Cariprazine hydrochloride
--- Chlorpromazine
--- Chlorpromazine embonate
--- Chlorpromazine hydrochloride
--- Chlorprothixene
--- Clozapine
--- Droperidol
--- Flupentixol
--- Flupentixol decanoate
--- Flupentixol dihydrochloride
--- Fluphenazine
--- Fluphenazine decanoate
--- Fluphenazine Enantate
--- Fluphenazine hydrochloride
--- Fluphenazine hydrochloride/Nortriptyline hydrochloride
--- Fluspirilene
--- Haloperidol
--- Haloperidol decanoate
--- Isopropamide Iodide/Trifluoperazine Hydrochloride
--- Levomepromazine hydrochloride
--- Levomepromazine maleate
--- Loxapine
--- Loxapine succinate
--- Lurasidone hydrochloride
--- Melperone hydrochloride
--- Nortriptyline hydrochloride/Fluphenazine hydrochloride
--- Olanzapine
--- Olanzapine embonate monohydrate
--- Oxypertine
--- Paliperidone
--- Paliperidone palmitate
--- Pericyazine
--- Perphenazine
--- Pimozide
--- Pipotiazine palmitate
--- Prochlorperazine
--- Prochlorperazine maleate
--- Prochlorperazine mesilate
--- Promazine
--- Promazine hydrochloride
--- Quetiapine
--- Quetiapine fumarate
--- Remoxipride Hydrochloride Monohydrate
--- Risperidone
--- Sertindole
--- Sulpiride
--- Thioridazine
--- Thioridazine hydrochloride
--- Trifluoperazine
--- Trifluoperazine hydrochloride
--- Trifluoperazine Hydrochloride/Tranylcypromine Sulphate
--- Trifluperidol
--- Ziprasidone hydrochloride
--- Zotepine
--- Zuclopenthixol
--- Zuclopenthixol acetate
--- Zuclopenthixol decanoate
--- Zuclopenthixol dihydrochloride
+Code set created using the following list from the PI of RQ051. Each component drug has its own code set and this is the union of the following:
 
-
+- Amisulpride (Solian)
+- Aripiprazole (Ablify/Arpoya)
+- Asenapine maleate (Sycrest)
+- Benperidol (Anquil/Benquil)
+- Cariprazine hydrochloride (Reagila)
+- Chlorpromazine (Chloractil/Chlorazin/Dozine/Largactil)
+- Chlorprothixene (Taractan/Truxal)
+- Clozapine (Clozaril/Denzapine/Zaponex)
+- Droperidol (Droleptan/Thalamonal/Xomolix)
+- Flupentixol (Depixol/Fluanxol/Flupenthixol/Psytixol)
+- Fluphenazine (Decazate/Modecate/Motipress/Moditen/Motival)
+- Fluspirilene (Imap/Redeptin)
+- Haloperidol (Dozic/Fortunan/Haldol/Halkid/Kentace/Serenace)
+- Levomepromazine (Levinan/Levorol/Methotrimeprazine/Nozinan/Veractil)
+- Loxapine (Adasuve/Loxapac)
+- Lurasidone hydrochloride (Latuda)
+- Melperone hydrochloride (Melperon-ratiopharm)
+- Olanzapine (Arkolamyl/Xyquila /Zalasta/Zypadhera/Zyprexa)
+- Oxypertine (Integrin)
+- Paliperidone (Byannli/Invega/Trevicta/Xeplion)
+- Pericyazine
+- Perphenazine
+- Pimozide
+- Pipotiazine palmitate
+- Prochlorperazine
+- Promazine
+- Quetiapine
+- Remoxipride Hydrochloride Monohydrate
+- Risperidone
+- Sertindole
+- Sulpiride
+- Thioridazine
+- Trifluoperazine
+- Trifluperidol
+- Ziprasidone hydrochloride
+- Zotepine
+- Zuclopenthixol
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `12.9 - 15.7%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `13% - 15.7%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-14 | EMIS            |    2448321 |   316670 (12.9%) |    316920 (12.9%) |
-| 2022-09-14 | TPP             |     198113 |    31106 (15.7%) |     31971 (16.1%) |
-| 2022-09-14 | Vision          |     325847 |    45079 (13.8%) |     45098 (13.8%) |
+| 2022-09-14 | EMIS            | 2448321    |   316670 (12.9%) |    316920 (12.9%) |
+| 2022-09-14 | TPP             | 198113     |    31106 (15.7%) |     31971 (16.1%) |
+| 2022-09-14 | Vision          | 325847     |    45079 (13.8%) |     45098 (13.8%) |
+| 2024-05-07 | EMIS            | 2516912    |     326391 (13%) |      326391 (13%) |
+| 2024-05-07 | TPP             | 200013     |    31318 (15.7%) |     31318 (15.7%) |
+| 2024-05-07 | Vision          | 334384     |      46957 (14%) |       46957 (14%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-07
+
 LINK: [https://github.com/rw251/.../medications/antipsychotics/2](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/antipsychotics/2)
 
 ### Antoconvusants
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
-    Carbamazepine
-    Lamotrigine
-    Sodium valproate
-    Valproate semisodium
-    Valproic acid
 
+- Carbamazepine
+- Lamotrigine
+- Sodium valproate
+- Valproate semisodium
+- Valproic acid
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range from the code is `1.9% - 2.4%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range from the code is `1.9% - 2.1%` suggesting that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |     46918 (1.9%) |      47012 (1.9%) |
-| 2022-09-08 | TPP             |     198144 |      4194 (2.1%) |       4817 (2.4%) |
-| 2022-09-08 | Vision          |     325732 |      6704 (2.1%) |       6707 (2.1%) |
+| 2022-09-08 | EMIS            | 2448237    |     46918 (1.9%) |      47012 (1.9%) |
+| 2022-09-08 | TPP             | 198144     |      4194 (2.1%) |       4817 (2.4%) |
+| 2022-09-08 | Vision          | 325732     |      6704 (2.1%) |       6707 (2.1%) |
+| 2024-05-02 | EMIS            | 2530927    |    48541 (1.92%) |     48541 (1.92%) |
+| 2024-05-02 | TPP             | 201816     |     4268 (2.11%) |      4268 (2.11%) |
+| 2024-05-02 | Vision          | 335411     |     7019 (2.09%) |      7019 (2.09%) |
+#### Audit log
 
+- Find_missing_codes last run 2024-05-02
 
 LINK: [https://github.com/rw251/.../medications/anticonvulsants/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/anticonvulsants/1)
 
 ### Lithium
+
+Any code for a prescription of lithium. Taken from the NHS drug refsets.
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.11% - 0.15%` suggests the code set is well defined across systems, however the prevalence seems low and may need checking.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.11% - 0.15%` suggests the code set is well defined across systems, with a slightly lower prevalence in TPP practices.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-15 | EMIS            | 2448321    |   3765 (0.15%)   |   	3783 (0.15%)   |
-| 2022-09-15 | TPP             | 198113     |    211 (0.11%)   |     259 (0.13%)   |
-| 2022-09-15 | Vision          | 325847     |    460 (0.14%)   |   	 460 (0.14%)   |
+| 2022-09-15 | EMIS            | 2448321    |     3765 (0.15%) |      3783 (0.15%) |
+| 2022-09-15 | TPP             | 198113     |      211 (0.11%) |       259 (0.13%) |
+| 2022-09-15 | Vision          | 325847     |      460 (0.14%) |       460 (0.14%) |
+| 2024-05-02 | EMIS            | 2530927    |    3678 (0.145%) |     3678 (0.145%) |
+| 2024-05-02 | TPP             | 201816     |     213 (0.106%) |      213 (0.106%) |
+| 2024-05-02 | Vision          | 335411     |      470 (0.14%) |       470 (0.14%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
 
 LINK: [https://github.com/rw251/.../medications/lithium/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/lithium/1)
 
-### Off label mood stabilisers 
+### Off label mood stabilisers
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Gabapentin
--- Oxcarbazepine
--- Topiramate
 
+- Gabapentin (Neurontin)
+- Oxcarbazepine (Trileptal)
+- Topiramate (Topamax)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `5.9 - 6.7%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `6.1 - 6.6%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |    143169 (5.8%) |     143340 (5.9%) |
-| 2022-09-08 | TPP             |     198144 |     12653 (6.4%) |      13384 (6.7%) |
-| 2022-09-08 | Vision          |     325732 |     21077 (6.5%) |      21084 (6.5%) |
+| 2022-09-08 | EMIS            | 2448237    |    143169 (5.8%) |     143340 (5.9%) |
+| 2022-09-08 | TPP             | 198144     |     12653 (6.4%) |      13384 (6.7%) |
+| 2022-09-08 | Vision          | 325732     |     21077 (6.5%) |      21084 (6.5%) |
+| 2024-05-02 | EMIS            | 2530927    |   153657 (6.07%) |    153657 (6.07%) |
+| 2024-05-02 | TPP             | 201816     |    13147 (6.51%) |     13147 (6.51%) |
+| 2024-05-02 | Vision          | 335411     |    22262 (6.64%) |     22262 (6.64%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-01
+
 LINK: [https://github.com/rw251/.../medications/off-label-mood-stabilisers/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/off-label-mood-stabilisers/1)
 
 ### Attention deficit hyperactivity disorder medications
 
 This code set was created from getset.ga, using the following list from the PI of RQ051:
--- Amfetamine/Dexamfetamine
--- Amfetamine/Dexamfetamine Sulphate
--- Atomoxetine hydrochloride
--- Dexamfetamine Sulphate
--- Dexedrine
--- Dexmethylphenidate hydrochloride
--- Guanfacine hydrochloride
--- Lisdexamfetamine dimesylate
--- Methylphenidate hydrochloride
--- Modafinil
--- Pitolisant hydrochloride
--- Ritalin
 
+- Amfetamine/Dexamfetamine (Adderall/Durophet)
+- Atomoxetine hydrochloride (Atomaid/Strattera)
+- Dexamfetamine Sulphate (Amfexa/Dexamphetamine/Dexedrine/Dextroamphetamine)
+- Dexmethylphenidate hydrochloride (Focalin)
+- Guanfacine hydrochloride (Intuniv/Tenex)
+- Lisdexamfetamine dimesylate (Elvanse/Vyvanse)
+- Methylphenidate hydrochloride (Affenid/Concerta/Delmosart/Equasym/Matoride/Medikinet/Meflynate/Metyrol/Ritalin/Tranquilyn/Xaggitin/Xenidate)
+- Modafinil (Provigil)
+- Pitolisant hydrochloride (Wakix)
 #### Prevalence log
 
-By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.5 - 0.7%` suggests that this code set is well defined.
+By examining the prevalence of codes (number of patients with the code in their record) broken down by clinical system, we can attempt to validate the clinical code sets and the reporting of the conditions. Here is a log for this code set. The prevalence range `0.7% - 0.9%` suggests that this code set is well defined.
 
 | Date       | Practice system | Population | Patients from ID | Patient from code |
 | ---------- | --------------- | ---------- | ---------------: | ----------------: |
-| 2022-09-08 | EMIS            |    2448237 |     12298 (0.5%) |      12333 (0.5%) |
-| 2022-09-08 | TPP             |     198144 |      1172 (0.6%) |       1340 (0.7%) |
-| 2022-09-08 | Vision          |     325732 |      2229 (0.7%) |       2229 (0.7%) |
+| 2022-09-08 | EMIS            | 2448237    |     12298 (0.5%) |      12333 (0.5%) |
+| 2022-09-08 | TPP             | 198144     |      1172 (0.6%) |       1340 (0.7%) |
+| 2022-09-08 | Vision          | 325732     |      2229 (0.7%) |       2229 (0.7%) |
+| 2024-05-07 | EMIS            | 2516912    |   18135 (0.721%) |    18135 (0.721%) |
+| 2024-05-07 | TPP             | 200013     |    1444 (0.722%) |     1444 (0.722%) |
+| 2024-05-07 | Vision          | 334384     |    3158 (0.944%) |     3158 (0.944%) |
+#### Audit log
+
+- Find_missing_codes last run 2024-05-07
+
 LINK: [https://github.com/rw251/.../medications/attention-deficit-hyperactivity-disorder-medications/1](https://github.com/rw251/gm-idcr/tree/master/shared/clinical-code-sets/medications/attention-deficit-hyperactivity-disorder-medications/1)
 # Clinical code sets
 

--- a/projects/051 - Webb/extraction-sql/population-March-2024.sql
+++ b/projects/051 - Webb/extraction-sql/population-March-2024.sql
@@ -1,5 +1,5 @@
 ﻿--+--------------------------------------------------------------------------------+
---¦ GP population counts in May 2022     					   ¦
+--¦ GP population counts in March 2024     					   ¦
 --+--------------------------------------------------------------------------------+
 
 -------- RESEARCH DATA ENGINEER CHECK ---------
@@ -447,7 +447,7 @@ IF OBJECT_ID('tempdb..#Table') IS NOT NULL DROP TABLE #Table;
 SELECT h.FK_Patient_Link_ID, h.GPPracticeCode, h.StartDate, h.EndDate, l.DeathDate
 INTO #Table
 FROM #GPHistory h
-LEFT OUTER JOIN [RLS].[vw_Patient_Link] l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
+LEFT OUTER JOIN SharedCare.Patient_Link l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
 
 
 -- Update the table with death date information===========================================================================================================

--- a/projects/051 - Webb/extraction-sql/population-March-2024.sql
+++ b/projects/051 - Webb/extraction-sql/population-March-2024.sql
@@ -1,0 +1,569 @@
+﻿--+--------------------------------------------------------------------------------+
+--¦ GP population counts in May 2022     					   ¦
+--+--------------------------------------------------------------------------------+
+
+-------- RESEARCH DATA ENGINEER CHECK ---------
+
+-- OUTPUT: Data with the following fields
+-- Year (YYYY)
+-- Month (1-12)
+-- CCG (can be an anonymised id for each CCG)
+-- GPPracticeId
+-- Age
+-- Sex
+-- Ethnic
+-- IMDGroup
+-- NumberOfPatients (integer)
+
+--Just want the output, not the messages
+SET NOCOUNT ON;
+
+-- Create a table with all patients (ID)=========================================================================================================================
+IF OBJECT_ID('tempdb..#Patients') IS NOT NULL DROP TABLE #Patients;
+SELECT DISTINCT FK_Patient_Link_ID
+INTO #Patients
+FROM SharedCare.Patient
+WHERE FK_Reference_Tenancy_ID=2
+AND GPPracticeCode NOT LIKE 'ZZZ%';
+-- 13s
+
+--┌───────────────┐
+--│ Year of birth │
+--└───────────────┘
+
+-- OBJECTIVE: To get the year of birth for each patient.
+
+-- INPUT: Assumes there exists a temp table as follows:
+-- #Patients (FK_Patient_Link_ID)
+--  A distinct list of FK_Patient_Link_IDs for each patient in the cohort
+
+-- OUTPUT: A temp table as follows:
+-- #PatientYearOfBirth (FK_Patient_Link_ID, YearOfBirth)
+-- 	- FK_Patient_Link_ID - unique patient id
+--	- YearOfBirth - INT
+
+-- ASSUMPTIONS:
+--	- Patient data is obtained from multiple sources. Where patients have multiple YOBs we determine the YOB as follows:
+--	-	If the patients has a YOB in their primary care data feed we use that as most likely to be up to date
+--	-	If every YOB for a patient is the same, then we use that
+--	-	If there is a single most recently updated YOB in the database then we use that
+--	-	Otherwise we take the highest YOB for the patient that is not in the future
+
+-- Get all patients year of birth for the cohort
+IF OBJECT_ID('tempdb..#AllPatientYearOfBirths') IS NOT NULL DROP TABLE #AllPatientYearOfBirths;
+SELECT 
+	FK_Patient_Link_ID,
+	FK_Reference_Tenancy_ID,
+	HDMModifDate,
+	YEAR(Dob) AS YearOfBirth
+INTO #AllPatientYearOfBirths
+FROM SharedCare.Patient p
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND Dob IS NOT NULL;
+
+
+-- If patients have a tenancy id of 2 we take this as their most likely YOB
+-- as this is the GP data feed and so most likely to be up to date
+IF OBJECT_ID('tempdb..#PatientYearOfBirth') IS NOT NULL DROP TABLE #PatientYearOfBirth;
+SELECT FK_Patient_Link_ID, MIN(YearOfBirth) as YearOfBirth INTO #PatientYearOfBirth FROM #AllPatientYearOfBirths
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND FK_Reference_Tenancy_ID = 2
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(YearOfBirth) = MAX(YearOfBirth);
+
+-- Find the patients who remain unmatched
+IF OBJECT_ID('tempdb..#UnmatchedYobPatients') IS NOT NULL DROP TABLE #UnmatchedYobPatients;
+SELECT FK_Patient_Link_ID INTO #UnmatchedYobPatients FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientYearOfBirth;
+
+-- If every YOB is the same for all their linked patient ids then we use that
+INSERT INTO #PatientYearOfBirth
+SELECT FK_Patient_Link_ID, MIN(YearOfBirth) FROM #AllPatientYearOfBirths
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedYobPatients)
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(YearOfBirth) = MAX(YearOfBirth);
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedYobPatients;
+INSERT INTO #UnmatchedYobPatients
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientYearOfBirth;
+
+-- If there is a unique most recent YOB then use that
+INSERT INTO #PatientYearOfBirth
+SELECT p.FK_Patient_Link_ID, MIN(p.YearOfBirth) FROM #AllPatientYearOfBirths p
+INNER JOIN (
+	SELECT FK_Patient_Link_ID, MAX(HDMModifDate) MostRecentDate FROM #AllPatientYearOfBirths
+	WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedYobPatients)
+	GROUP BY FK_Patient_Link_ID
+) sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.MostRecentDate = p.HDMModifDate
+GROUP BY p.FK_Patient_Link_ID
+HAVING MIN(YearOfBirth) = MAX(YearOfBirth);
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedYobPatients;
+INSERT INTO #UnmatchedYobPatients
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientYearOfBirth;
+
+-- Otherwise just use the highest value (with the exception that can't be in the future)
+INSERT INTO #PatientYearOfBirth
+SELECT FK_Patient_Link_ID, MAX(YearOfBirth) FROM #AllPatientYearOfBirths
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedYobPatients)
+GROUP BY FK_Patient_Link_ID
+HAVING MAX(YearOfBirth) <= YEAR(GETDATE());
+
+-- Tidy up - helpful in ensuring the tempdb doesn't run out of space mid-query
+DROP TABLE #AllPatientYearOfBirths;
+DROP TABLE #UnmatchedYobPatients;
+-- 20s
+
+-- Max age is 24 and first year is 2019, so we can exclude everyone born in 1994 and before.
+TRUNCATE TABLE #Patients;
+INSERT INTO #Patients
+SELECT FK_Patient_Link_ID FROM #PatientYearOfBirth WHERE YearOfBirth > 1994;
+
+--┌──────────────────┐
+--│ CCG lookup table │
+--└──────────────────┘
+
+-- OBJECTIVE: To provide lookup table for CCG names. The GMCR provides the CCG id (e.g. '00T', '01G') but not 
+--            the CCG name. This table can be used in other queries when the output is required to be a ccg 
+--            name rather than an id.
+
+-- INPUT: No pre-requisites
+
+-- OUTPUT: A temp table as follows:
+-- #CCGLookup (CcgId, CcgName)
+-- 	- CcgId - Nationally recognised ccg id
+--	- CcgName - Bolton, Stockport etc..
+
+IF OBJECT_ID('tempdb..#CCGLookup') IS NOT NULL DROP TABLE #CCGLookup;
+CREATE TABLE #CCGLookup (CcgId nchar(3), CcgName nvarchar(20));
+INSERT INTO #CCGLookup VALUES ('01G', 'Salford'); 
+INSERT INTO #CCGLookup VALUES ('00T', 'Bolton'); 
+INSERT INTO #CCGLookup VALUES ('01D', 'HMR'); 
+INSERT INTO #CCGLookup VALUES ('02A', 'Trafford'); 
+INSERT INTO #CCGLookup VALUES ('01W', 'Stockport');
+INSERT INTO #CCGLookup VALUES ('00Y', 'Oldham'); 
+INSERT INTO #CCGLookup VALUES ('02H', 'Wigan'); 
+INSERT INTO #CCGLookup VALUES ('00V', 'Bury'); 
+INSERT INTO #CCGLookup VALUES ('14L', 'Manchester'); 
+INSERT INTO #CCGLookup VALUES ('01Y', 'Tameside Glossop'); 
+--┌─────┐
+--│ Sex │
+--└─────┘
+
+-- OBJECTIVE: To get the Sex for each patient.
+
+-- INPUT: Assumes there exists a temp table as follows:
+-- #Patients (FK_Patient_Link_ID)
+--  A distinct list of FK_Patient_Link_IDs for each patient in the cohort
+
+-- OUTPUT: A temp table as follows:
+-- #PatientSex (FK_Patient_Link_ID, Sex)
+-- 	- FK_Patient_Link_ID - unique patient id
+--	- Sex - M/F
+
+-- ASSUMPTIONS:
+--	- Patient data is obtained from multiple sources. Where patients have multiple sexes we determine the sex as follows:
+--	-	If the patients has a sex in their primary care data feed we use that as most likely to be up to date
+--	-	If every sex for a patient is the same, then we use that
+--	-	If there is a single most recently updated sex in the database then we use that
+--	-	Otherwise the patient's sex is considered unknown
+
+-- Get all patients sex for the cohort
+IF OBJECT_ID('tempdb..#AllPatientSexs') IS NOT NULL DROP TABLE #AllPatientSexs;
+SELECT 
+	FK_Patient_Link_ID,
+	FK_Reference_Tenancy_ID,
+	HDMModifDate,
+	Sex
+INTO #AllPatientSexs
+FROM SharedCare.Patient p
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND Sex IS NOT NULL;
+
+
+-- If patients have a tenancy id of 2 we take this as their most likely Sex
+-- as this is the GP data feed and so most likely to be up to date
+IF OBJECT_ID('tempdb..#PatientSex') IS NOT NULL DROP TABLE #PatientSex;
+SELECT FK_Patient_Link_ID, MIN(Sex) as Sex INTO #PatientSex FROM #AllPatientSexs
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND FK_Reference_Tenancy_ID = 2
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(Sex) = MAX(Sex);
+
+-- Find the patients who remain unmatched
+IF OBJECT_ID('tempdb..#UnmatchedSexPatients') IS NOT NULL DROP TABLE #UnmatchedSexPatients;
+SELECT FK_Patient_Link_ID INTO #UnmatchedSexPatients FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientSex;
+
+-- If every Sex is the same for all their linked patient ids then we use that
+INSERT INTO #PatientSex
+SELECT FK_Patient_Link_ID, MIN(Sex) FROM #AllPatientSexs
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedSexPatients)
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(Sex) = MAX(Sex);
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedSexPatients;
+INSERT INTO #UnmatchedSexPatients
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientSex;
+
+-- If there is a unique most recent Sex then use that
+INSERT INTO #PatientSex
+SELECT p.FK_Patient_Link_ID, MIN(p.Sex) FROM #AllPatientSexs p
+INNER JOIN (
+	SELECT FK_Patient_Link_ID, MAX(HDMModifDate) MostRecentDate FROM #AllPatientSexs
+	WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedSexPatients)
+	GROUP BY FK_Patient_Link_ID
+) sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.MostRecentDate = p.HDMModifDate
+GROUP BY p.FK_Patient_Link_ID
+HAVING MIN(Sex) = MAX(Sex);
+
+-- Tidy up - helpful in ensuring the tempdb doesn't run out of space mid-query
+DROP TABLE #AllPatientSexs;
+DROP TABLE #UnmatchedSexPatients;
+--┌────────────────────────────┐
+--│ Index Multiple Deprivation │
+--└────────────────────────────┘
+
+-- OBJECTIVE: To get the 2019 Index of Multiple Deprivation (IMD) decile for each patient.
+
+-- INPUT: Assumes there exists a temp table as follows:
+-- #Patients (FK_Patient_Link_ID)
+--  A distinct list of FK_Patient_Link_IDs for each patient in the cohort
+
+-- OUTPUT: A temp table as follows:
+-- #PatientIMDDecile (FK_Patient_Link_ID, IMD2019Decile1IsMostDeprived10IsLeastDeprived)
+-- 	- FK_Patient_Link_ID - unique patient id
+--	- IMD2019Decile1IsMostDeprived10IsLeastDeprived - number 1 to 10 inclusive
+
+-- Get all patients IMD_Score (which is a rank) for the cohort and map to decile
+-- (Data on mapping thresholds at: https://www.gov.uk/government/statistics/english-indices-of-deprivation-2019
+IF OBJECT_ID('tempdb..#AllPatientIMDDeciles') IS NOT NULL DROP TABLE #AllPatientIMDDeciles;
+SELECT 
+	FK_Patient_Link_ID,
+	FK_Reference_Tenancy_ID,
+	HDMModifDate,
+	CASE 
+		WHEN IMD_Score <= 3284 THEN 1
+		WHEN IMD_Score <= 6568 THEN 2
+		WHEN IMD_Score <= 9853 THEN 3
+		WHEN IMD_Score <= 13137 THEN 4
+		WHEN IMD_Score <= 16422 THEN 5
+		WHEN IMD_Score <= 19706 THEN 6
+		WHEN IMD_Score <= 22990 THEN 7
+		WHEN IMD_Score <= 26275 THEN 8
+		WHEN IMD_Score <= 29559 THEN 9
+		ELSE 10
+	END AS IMD2019Decile1IsMostDeprived10IsLeastDeprived 
+INTO #AllPatientIMDDeciles
+FROM SharedCare.Patient p
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND IMD_Score IS NOT NULL
+AND IMD_Score != -1;
+-- 972479 rows
+-- 00:00:11
+
+-- If patients have a tenancy id of 2 we take this as their most likely IMD_Score
+-- as this is the GP data feed and so most likely to be up to date
+IF OBJECT_ID('tempdb..#PatientIMDDecile') IS NOT NULL DROP TABLE #PatientIMDDecile;
+SELECT FK_Patient_Link_ID, MIN(IMD2019Decile1IsMostDeprived10IsLeastDeprived) as IMD2019Decile1IsMostDeprived10IsLeastDeprived INTO #PatientIMDDecile FROM #AllPatientIMDDeciles
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND FK_Reference_Tenancy_ID = 2
+GROUP BY FK_Patient_Link_ID;
+-- 247377 rows
+-- 00:00:00
+
+-- Find the patients who remain unmatched
+IF OBJECT_ID('tempdb..#UnmatchedImdPatients') IS NOT NULL DROP TABLE #UnmatchedImdPatients;
+SELECT FK_Patient_Link_ID INTO #UnmatchedImdPatients FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientIMDDecile;
+-- 38710 rows
+-- 00:00:00
+
+-- If every IMD_Score is the same for all their linked patient ids then we use that
+INSERT INTO #PatientIMDDecile
+SELECT FK_Patient_Link_ID, MIN(IMD2019Decile1IsMostDeprived10IsLeastDeprived) FROM #AllPatientIMDDeciles
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedImdPatients)
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(IMD2019Decile1IsMostDeprived10IsLeastDeprived) = MAX(IMD2019Decile1IsMostDeprived10IsLeastDeprived);
+-- 36656
+-- 00:00:00
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedImdPatients;
+INSERT INTO #UnmatchedImdPatients
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientIMDDecile;
+-- 2054 rows
+-- 00:00:00
+
+-- If there is a unique most recent imd decile then use that
+INSERT INTO #PatientIMDDecile
+SELECT p.FK_Patient_Link_ID, MIN(p.IMD2019Decile1IsMostDeprived10IsLeastDeprived) FROM #AllPatientIMDDeciles p
+INNER JOIN (
+	SELECT FK_Patient_Link_ID, MAX(HDMModifDate) MostRecentDate FROM #AllPatientIMDDeciles
+	WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedImdPatients)
+	GROUP BY FK_Patient_Link_ID
+) sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.MostRecentDate = p.HDMModifDate
+GROUP BY p.FK_Patient_Link_ID
+HAVING MIN(IMD2019Decile1IsMostDeprived10IsLeastDeprived) = MAX(IMD2019Decile1IsMostDeprived10IsLeastDeprived);
+-- 489
+-- 00:00:00
+--┌───────────────────────────────────────┐
+--│ GET practice and ccg for each patient │
+--└───────────────────────────────────────┘
+
+-- OBJECTIVE:	For each patient to get the practice id that they are registered to, and 
+--						the CCG name that the practice belongs to.
+
+-- INPUT: Assumes there exists a temp table as follows:
+-- #Patients (FK_Patient_Link_ID)
+--  A distinct list of FK_Patient_Link_IDs for each patient in the cohort
+
+-- OUTPUT: Two temp tables as follows:
+-- #PatientPractice (FK_Patient_Link_ID, GPPracticeCode)
+--	- FK_Patient_Link_ID - unique patient id
+--	- GPPracticeCode - the nationally recognised practice id for the patient
+-- #PatientPracticeAndCCG (FK_Patient_Link_ID, GPPracticeCode, CCG)
+--	- FK_Patient_Link_ID - unique patient id
+--	- GPPracticeCode - the nationally recognised practice id for the patient
+--	- CCG - the name of the patient's CCG
+
+-- If patients have a tenancy id of 2 we take this as their most likely GP practice
+-- as this is the GP data feed and so most likely to be up to date
+IF OBJECT_ID('tempdb..#PatientPractice') IS NOT NULL DROP TABLE #PatientPractice;
+SELECT FK_Patient_Link_ID, MIN(GPPracticeCode) as GPPracticeCode INTO #PatientPractice FROM SharedCare.Patient
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients)
+AND FK_Reference_Tenancy_ID = 2
+AND GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID;
+-- 1298467 rows
+-- 00:00:11
+
+-- Find the patients who remain unmatched
+IF OBJECT_ID('tempdb..#UnmatchedPatientsForPracticeCode') IS NOT NULL DROP TABLE #UnmatchedPatientsForPracticeCode;
+SELECT FK_Patient_Link_ID INTO #UnmatchedPatientsForPracticeCode FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientPractice;
+-- 12702 rows
+-- 00:00:00
+
+-- If every GPPracticeCode is the same for all their linked patient ids then we use that
+INSERT INTO #PatientPractice
+SELECT FK_Patient_Link_ID, MIN(GPPracticeCode) FROM SharedCare.Patient
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedPatientsForPracticeCode)
+AND GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(GPPracticeCode) = MAX(GPPracticeCode);
+-- 12141
+-- 00:00:00
+
+-- Find any still unmatched patients
+TRUNCATE TABLE #UnmatchedPatientsForPracticeCode;
+INSERT INTO #UnmatchedPatientsForPracticeCode
+SELECT FK_Patient_Link_ID FROM #Patients
+EXCEPT
+SELECT FK_Patient_Link_ID FROM #PatientPractice;
+-- 561 rows
+-- 00:00:00
+
+-- If there is a unique most recent gp practice then we use that
+INSERT INTO #PatientPractice
+SELECT p.FK_Patient_Link_ID, MIN(p.GPPracticeCode) FROM SharedCare.Patient p
+INNER JOIN (
+	SELECT FK_Patient_Link_ID, MAX(HDMModifDate) MostRecentDate FROM SharedCare.Patient
+	WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #UnmatchedPatientsForPracticeCode)
+	GROUP BY FK_Patient_Link_ID
+) sub ON sub.FK_Patient_Link_ID = p.FK_Patient_Link_ID AND sub.MostRecentDate = p.HDMModifDate
+WHERE p.GPPracticeCode IS NOT NULL
+GROUP BY p.FK_Patient_Link_ID
+HAVING MIN(GPPracticeCode) = MAX(GPPracticeCode);
+-- 15
+
+-- >>> Ignoring following query as already injected: query-ccg-lookup.sql
+
+IF OBJECT_ID('tempdb..#PatientPracticeAndCCG') IS NOT NULL DROP TABLE #PatientPracticeAndCCG;
+SELECT p.FK_Patient_Link_ID, ISNULL(pp.GPPracticeCode,'') AS GPPracticeCode, ISNULL(ccg.CcgName, '') AS CCG
+INTO #PatientPracticeAndCCG
+FROM #Patients p
+LEFT OUTER JOIN #PatientPractice pp ON pp.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN SharedCare.Reference_GP_Practice gp ON gp.OrganisationCode = pp.GPPracticeCode
+LEFT OUTER JOIN #CCGLookup ccg ON ccg.CcgId = gp.Commissioner;
+
+/*
+
+This is the logic we apply to the GP_History table to find which practice a patient was most likely
+registered at on a given date - DateOfInterest.
+
+-      Find all practices where the patient’s start date <=DateOfInterest, and end date is NULL or >=DateOfInterest
+-      Where registration periods overlap they use the one with the most recent start date
+-      If there are several with the same start date they use the longest one (i.e. with the latest end date).
+
+*/
+
+
+-- Create a table populated with the time points that we want to find the GP population for
+IF OBJECT_ID('tempdb..#DatesOfInterest') IS NOT NULL DROP TABLE #DatesOfInterest;
+CREATE TABLE #DatesOfInterest (
+       [DateOfInterest] DATE
+);
+
+INSERT INTO #DatesOfInterest
+VALUES ('2019-01-15'), ('2019-02-15'), ('2019-03-15'), ('2019-04-15'), ('2019-05-15'), ('2019-06-15'),
+	   ('2019-07-15'), ('2019-08-15'), ('2019-09-15'), ('2019-10-15'), ('2019-11-15'), ('2019-12-15'),
+	   ('2020-01-15'), ('2020-02-15'), ('2020-03-15'), ('2020-04-15'), ('2020-05-15'), ('2020-06-15'),
+	   ('2020-07-15'), ('2020-08-15'), ('2020-09-15'), ('2020-10-15'), ('2020-11-15'), ('2020-12-15'),
+	   ('2021-01-15'), ('2021-02-15'), ('2021-03-15'), ('2021-04-15'), ('2021-05-15'), ('2021-06-15'),
+	   ('2021-07-15'), ('2021-08-15'), ('2021-09-15'), ('2021-10-15'), ('2021-11-15'), ('2021-12-15'),
+	   ('2022-01-15'), ('2022-02-15'), ('2022-03-15'), ('2022-04-15'), ('2022-05-15'), ('2022-06-15'),
+		 ('2022-07-15'), ('2022-08-15'), ('2022-09-15'), ('2022-10-15'), ('2022-11-15'), ('2022-12-15'),
+		 ('2023-01-15'), ('2023-02-15'), ('2023-03-15'), ('2023-04-15'), ('2023-05-15'), ('2023-06-15'),
+		 ('2023-07-15'), ('2023-08-15'), ('2023-09-15'), ('2023-10-15'), ('2023-11-15'), ('2023-12-15'),
+		 ('2024-01-15'), ('2024-02-15'), ('2024-03-15'), ('2024-04-15'), ('2024-05-15');
+
+
+-- Create a table of all patients with start date and end date in GP history table================================================================================================================
+IF OBJECT_ID('tempdb..#GPHistory') IS NOT NULL DROP TABLE #GPHistory;
+SELECT FK_Patient_Link_ID, StartDate, EndDate, GPPracticeCode
+INTO #GPHistory
+FROM SharedCare.Patient_GP_History
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients);
+
+
+-- Merge with death date=========================================================================================================================================================================
+IF OBJECT_ID('tempdb..#Table') IS NOT NULL DROP TABLE #Table;
+SELECT h.FK_Patient_Link_ID, h.GPPracticeCode, h.StartDate, h.EndDate, l.DeathDate
+INTO #Table
+FROM #GPHistory h
+LEFT OUTER JOIN [RLS].[vw_Patient_Link] l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
+
+
+-- Update the table with death date information===========================================================================================================
+UPDATE
+#Table
+SET
+EndDate = DeathDate
+WHERE
+EndDate IS NULL OR DeathDate < EndDate;
+
+
+UPDATE
+#Table
+SET
+StartDate = DeathDate
+WHERE
+DeathDate < StartDate;
+
+
+-- For each patient with a matching registration period for each date of interest, we find
+-- the most recent start date (NB this can match multiple rows for each patient and each date of interest)
+IF OBJECT_ID('tempdb..#MostRecentStartDates') IS NOT NULL DROP TABLE #MostRecentStartDates;
+SELECT FK_Patient_Link_ID, DateOfInterest, MAX(StartDate) AS LatestStartDate INTO #MostRecentStartDates
+FROM #Table h
+INNER JOIN #DatesOfInterest d ON CAST(StartDate AS DATE) <= d.DateOfInterest AND (EndDate IS NULL OR CAST(EndDate AS DATE) >= d.DateOfInterest)
+WHERE GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID, DateOfInterest;
+-- 3m29
+
+
+-- We now link the patient ids and start dates back to the GP_History table, so that for cases
+-- where a patient has multiple startdates, we can pick the one with the furthest end date. (NB
+-- this can still lead to multiple rows for each patient and each date of interest)
+IF OBJECT_ID('tempdb..#FurthestEndDates') IS NOT NULL DROP TABLE #FurthestEndDates;
+SELECT h.FK_Patient_Link_ID, DateOfInterest, StartDate, MAX(CASE WHEN EndDate IS NULL THEN '2100-01-01' ELSE EndDate END) AS LatestEndDate INTO #FurthestEndDates
+FROM #Table h
+INNER JOIN #MostRecentStartDates m 
+       ON m.FK_Patient_Link_ID = h.FK_Patient_Link_ID
+       AND m.LatestStartDate = StartDate
+       AND (EndDate IS NULL OR CAST(EndDate AS DATE) >= DateOfInterest)
+GROUP BY h.FK_Patient_Link_ID, DateOfInterest, StartDate;
+-- 2m23
+
+
+-- Bring it all together into a table that shows which practice each person was at
+-- for each date of interest
+IF OBJECT_ID('tempdb..#PatientGPPracticesOnDate') IS NOT NULL DROP TABLE #PatientGPPracticesOnDate;
+SELECT h.FK_Patient_Link_ID, MAX(GPPracticeCode) AS GPPracticeCode, YEAR (DateOfInterest) AS Year, MONTH (DateOfInterest) AS Month, DAY(DateOfInterest) AS Day
+INTO #PatientGPPracticesOnDate
+FROM #Table h
+INNER JOIN #FurthestEndDates f
+       ON f.FK_Patient_Link_ID = h.FK_Patient_Link_ID
+       AND f.StartDate = h.StartDate
+       AND (
+             f.LatestEndDate = h.EndDate 
+             OR (h.EndDate IS NULL AND f.LatestEndDate='2100-01-01')
+       )
+WHERE GPPracticeCode IS NOT NULL
+GROUP BY h.FK_Patient_Link_ID, DateOfInterest;
+
+
+-- Create the table of ethnic================================================================================================================================
+IF OBJECT_ID('tempdb..#Ethnicities') IS NOT NULL DROP TABLE #Ethnicities;
+SELECT 
+  PK_Patient_Link_ID AS FK_Patient_Link_ID,
+  CASE 
+    WHEN EthnicMainGroup IS NULL THEN 'Refused and not stated group'
+    ELSE EthnicMainGroup
+  END AS Ethnicity
+INTO #Ethnicities
+FROM SharedCare.Patient_Link
+WHERE PK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients);
+
+
+
+-- Create the table of IDM================================================================================================================================
+IF OBJECT_ID('tempdb..#IMDGroup') IS NOT NULL DROP TABLE #IMDGroup;
+SELECT FK_Patient_Link_ID, IMDGroup = CASE 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (1,2) THEN 1 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (3,4) THEN 2 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (5,6) THEN 3
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (7,8) THEN 4
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (9,10) THEN 5
+		ELSE NULL END
+INTO #IMDGroup
+FROM #PatientIMDDecile;
+
+
+-- Merge CCG information============================================================================================================================================
+IF OBJECT_ID('tempdb..#FinalTable') IS NOT NULL DROP TABLE #FinalTable;
+SELECT p.FK_Patient_Link_ID, 
+	p.GPPracticeCode, 
+	p.Year, 
+	p.Month,
+	p.Day,
+	ISNULL(ccg.CcgName, '') AS CCG, 
+	Sex,
+	Ethnicity,
+	(p.Year - YearOfBirth) AS Age,
+  	IMDGroup
+INTO #FinalTable
+FROM #PatientGPPracticesOnDate p
+LEFT OUTER JOIN SharedCare.Reference_GP_Practice gp ON gp.OrganisationCode = p.GPPracticeCode
+LEFT OUTER JOIN #CCGLookup ccg ON ccg.CcgId = gp.Commissioner
+LEFT OUTER JOIN #Ethnicities e ON e.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientYearOfBirth yob ON yob.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientSex sex ON sex.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #IMDGroup imd ON imd.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+WHERE Sex != 'U';
+
+
+-- Count============================================================================================================================================================
+SELECT Year, Month, Sex, Age, Ethnicity, IMDGroup, CCG, GPPracticeCode AS GPPracticeId, 
+	   SUM(CASE WHEN Day IS NOT NULL THEN 1 ELSE 0 END) AS NumberOfPatients
+FROM #FinalTable
+WHERE Year = 2024 AND Month = 3
+GROUP BY Year, Month, Age, Sex, Ethnicity, IMDGroup, GPPracticeCode, CCG
+ORDER BY Year, Month, Age, Sex, Ethnicity, IMDGroup, GPPracticeCode, CCG;
+

--- a/projects/051 - Webb/extraction-sql/population-May-2022.sql
+++ b/projects/051 - Webb/extraction-sql/population-May-2022.sql
@@ -15,16 +15,26 @@
 -- IMDGroup
 -- NumberOfPatients (integer)
 
+-- Set the start date
+DECLARE @StartDate datetime;
+DECLARE @EndDate datetime;
+SET @StartDate = '2019-01-01';
+SET @EndDate = '2022-06-01';
+
 --Just want the output, not the messages
 SET NOCOUNT ON;
 
 -- Create a table with all patients (ID)=========================================================================================================================
+IF OBJECT_ID('tempdb..#PatientsToInclude') IS NOT NULL DROP TABLE #PatientsToInclude;
+SELECT FK_Patient_Link_ID INTO #PatientsToInclude
+FROM SharedCare.Patient_GP_History
+GROUP BY FK_Patient_Link_ID
+HAVING MIN(StartDate) < '2022-06-01';
+
 IF OBJECT_ID('tempdb..#Patients') IS NOT NULL DROP TABLE #Patients;
-SELECT DISTINCT FK_Patient_Link_ID
-INTO #Patients
-FROM SharedCare.Patient
-WHERE FK_Reference_Tenancy_ID=2
-AND GPPracticeCode NOT LIKE 'ZZZ%';
+SELECT DISTINCT FK_Patient_Link_ID 
+INTO #Patients 
+FROM #PatientsToInclude;
 
 
 --┌──────────────────┐

--- a/projects/051 - Webb/extraction-sql/population-May-2022.sql
+++ b/projects/051 - Webb/extraction-sql/population-May-2022.sql
@@ -15,26 +15,16 @@
 -- IMDGroup
 -- NumberOfPatients (integer)
 
--- Set the start date
-DECLARE @StartDate datetime;
-DECLARE @EndDate datetime;
-SET @StartDate = '2019-01-01';
-SET @EndDate = '2022-06-01';
-
 --Just want the output, not the messages
 SET NOCOUNT ON;
 
 -- Create a table with all patients (ID)=========================================================================================================================
-IF OBJECT_ID('tempdb..#PatientsToInclude') IS NOT NULL DROP TABLE #PatientsToInclude;
-SELECT FK_Patient_Link_ID INTO #PatientsToInclude
-FROM SharedCare.Patient_GP_History
-GROUP BY FK_Patient_Link_ID
-HAVING MIN(StartDate) < '2022-06-01';
-
 IF OBJECT_ID('tempdb..#Patients') IS NOT NULL DROP TABLE #Patients;
-SELECT DISTINCT FK_Patient_Link_ID 
-INTO #Patients 
-FROM #PatientsToInclude;
+SELECT DISTINCT FK_Patient_Link_ID
+INTO #Patients
+FROM SharedCare.Patient
+WHERE FK_Reference_Tenancy_ID=2
+AND GPPracticeCode NOT LIKE 'ZZZ%';
 
 
 --┌──────────────────┐

--- a/projects/051 - Webb/scripts/analyst-guidance.md
+++ b/projects/051 - Webb/scripts/analyst-guidance.md
@@ -33,6 +33,8 @@
 
 - Anything else (e.g. documentation that is not code) goes in the 'doc' folder.
 
+- Export files: you can copy the files you want to export to the redirected C or P drive in the VDE (under "Redirected drives and folders" in "This PC" folder in VDE) and they will appear in the C or P drive in your laptop.
+
 - NB. There are known issues with using RStudio on a network shared drive. If you experience slow performance please read the documentation here: https://drive.google.com/file/d/1nRuhT-FJ-Sioh0ntknktPN3kYQCc-5px/view?usp=sharing
 
 - **_NB. Please do not attempt to install extra software on the VDEs. Instead let your RDE know and it can be arranged. This does not apply to R and Stata packages which can be installed in the usual way._**

--- a/projects/051 - Webb/scripts/main.js
+++ b/projects/051 - Webb/scripts/main.js
@@ -1,4 +1,10 @@
+// This file contains the logic for extracting data when an RDE
+// is ready to generate the data for a study. When the SQL is compiled
+// this file is copied to the "scripts" directory of the project. In
+// this way we can update a single js file (this one) rather than having
+// a separate file in each project directory
 const fs = require('fs');
+const readline = require('readline');
 const mssql = require('mssql');
 const msRestNodeAuth = require('@azure/ms-rest-nodeauth');
 const chalk = require('chalk');
@@ -463,7 +469,7 @@ async function getPatientPseudoIds() {
   return new Promise((resolve) => {
     const request = new mssql.Request();
     request.stream = true;
-    request.query('SELECT PK_Patient_Link_ID FROM RLS.vw_Patient_Link;');
+    request.query('SELECT PK_Patient_Link_ID FROM SharedCare.Patient_Link;');
 
     request.on('row', (row) => {
       // Emitted for each row in a recordset
@@ -476,34 +482,66 @@ async function getPatientPseudoIds() {
 ${err}`);
     });
 
-    request.on('done', () => {
+    request.on('done', async () => {
       // Always emitted as the last one
       if (!store.shouldOverwrite) {
         log('Loading the existing mapping file...');
         let maxPseudoId = 0;
-        fs.readFileSync(PSEUDO_ID_FILE, 'utf8')
-          .split('\n')
-          .forEach((x) => {
-            if (x.trim().length < 2) return;
-            const [fkid, pseudoId] = x.split(',');
+
+        const fileStream = fs.createReadStream(PSEUDO_ID_FILE);
+
+        const rl = readline.createInterface({
+          input: fileStream,
+          crlfDelay: Infinity, // treat \r\n as single line break
+        });
+
+        // Process one line at a time rather than reading entire file
+        // in one go as that was causing out of memory exceptions
+        for await (const line of rl) {
+          if (line.trim().length >= 2) {
+            const [fkid, pseudoId] = line.split(',');
             store.pseudoLookup[fkid.trim()] = +pseudoId.trim();
             maxPseudoId = Math.max(maxPseudoId, +pseudoId.trim());
-          });
+          }
+        }
+
         log(`There are ${Object.keys(store.pseudoLookup).length} patient ids in the mapping file.`);
         const newPatientIds = patientIds.filter((patientId) => !store.pseudoLookup[patientId]);
         log(`There are ${newPatientIds.length} new patient ids from the database.`);
         if (newPatientIds.length > 0) {
           const newPatientIdRows = randomIdGenerator(maxPseudoId, newPatientIds);
+          log('Appending new patient ids to the lookup file...');
           fs.writeFileSync(PSEUDO_ID_FILE, '\n' + newPatientIdRows.join('\n'), { flag: 'a' });
           log(`New patient ids added to the pseudo id lookup file.`);
         }
+        return resolve();
       } else {
         log(chalk.bold(`${patientIds.length} patient ids retrived.`));
         const patientIdRows = randomIdGenerator(0, patientIds);
-        fs.writeFileSync(PSEUDO_ID_FILE, patientIdRows.join('\n'));
-        log(`Patient ids written to the pseudo id lookup file.`);
+        log('Writing new patient ids to the lookup file...');
+        const pseudoFileWriter = fs.createWriteStream(PSEUDO_ID_FILE);
+        pseudoFileWriter.on('error', function (err) {
+          throw err;
+        });
+        pseudoFileWriter.on('close', () => {
+          log(`Patient ids written to the pseudo id lookup file.`);
+          return resolve();
+        });
+        let i = 0;
+        function writeToFile() {
+          let ok = true;
+          while (ok && i < patientIdRows.length) {
+            ok = pseudoFileWriter.write(patientIdRows[i] + '\n');
+            i++;
+          }
+          if (i === patientIdRows.length) pseudoFileWriter.end();
+          else pseudoFileWriter.once('drain', writeToFile);
+        }
+        writeToFile();
+
+        // pseudoFileWriter.end();
+        // fs.writeFileSync(PSEUDO_ID_FILE, patientIdRows.join('\n'));
       }
-      return resolve();
     });
   });
 }
@@ -511,6 +549,7 @@ ${err}`);
 function randomIdGenerator(start = 0, ids) {
   log('Randomly assigning ids...');
   shuffleArray(ids);
+  log('Array shuffling complete');
   return ids.map((id, i) => {
     store.highestId = start + i + 1;
     store.pseudoLookup[id] = store.highestId;

--- a/projects/051 - Webb/template-sql/population-March-2024.template.sql
+++ b/projects/051 - Webb/template-sql/population-March-2024.template.sql
@@ -1,5 +1,5 @@
 ﻿--+--------------------------------------------------------------------------------+
---¦ GP population counts in May 2022     					   ¦
+--¦ GP population counts in March 2024     					   ¦
 --+--------------------------------------------------------------------------------+
 
 -------- RESEARCH DATA ENGINEER CHECK ---------
@@ -85,7 +85,7 @@ IF OBJECT_ID('tempdb..#Table') IS NOT NULL DROP TABLE #Table;
 SELECT h.FK_Patient_Link_ID, h.GPPracticeCode, h.StartDate, h.EndDate, l.DeathDate
 INTO #Table
 FROM #GPHistory h
-LEFT OUTER JOIN [RLS].[vw_Patient_Link] l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
+LEFT OUTER JOIN SharedCare.Patient_Link l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
 
 
 -- Update the table with death date information===========================================================================================================

--- a/projects/051 - Webb/template-sql/population-March-2024.template.sql
+++ b/projects/051 - Webb/template-sql/population-March-2024.template.sql
@@ -1,0 +1,207 @@
+﻿--+--------------------------------------------------------------------------------+
+--¦ GP population counts in May 2022     					   ¦
+--+--------------------------------------------------------------------------------+
+
+-------- RESEARCH DATA ENGINEER CHECK ---------
+
+-- OUTPUT: Data with the following fields
+-- Year (YYYY)
+-- Month (1-12)
+-- CCG (can be an anonymised id for each CCG)
+-- GPPracticeId
+-- Age
+-- Sex
+-- Ethnic
+-- IMDGroup
+-- NumberOfPatients (integer)
+
+--Just want the output, not the messages
+SET NOCOUNT ON;
+
+-- Create a table with all patients (ID)=========================================================================================================================
+IF OBJECT_ID('tempdb..#Patients') IS NOT NULL DROP TABLE #Patients;
+SELECT DISTINCT FK_Patient_Link_ID
+INTO #Patients
+FROM SharedCare.Patient
+WHERE FK_Reference_Tenancy_ID=2
+AND GPPracticeCode NOT LIKE 'ZZZ%';
+-- 13s
+
+--> EXECUTE query-patient-year-of-birth.sql
+-- 20s
+
+-- Max age is 24 and first year is 2019, so we can exclude everyone born in 1994 and before.
+TRUNCATE TABLE #Patients;
+INSERT INTO #Patients
+SELECT FK_Patient_Link_ID FROM #PatientYearOfBirth WHERE YearOfBirth > 1994;
+
+--> EXECUTE query-ccg-lookup.sql
+--> EXECUTE query-patient-sex.sql
+--> EXECUTE query-patient-imd.sql
+--> EXECUTE query-patient-practice-and-ccg.sql
+
+/*
+
+This is the logic we apply to the GP_History table to find which practice a patient was most likely
+registered at on a given date - DateOfInterest.
+
+-      Find all practices where the patient’s start date <=DateOfInterest, and end date is NULL or >=DateOfInterest
+-      Where registration periods overlap they use the one with the most recent start date
+-      If there are several with the same start date they use the longest one (i.e. with the latest end date).
+
+*/
+
+
+-- Create a table populated with the time points that we want to find the GP population for
+IF OBJECT_ID('tempdb..#DatesOfInterest') IS NOT NULL DROP TABLE #DatesOfInterest;
+CREATE TABLE #DatesOfInterest (
+       [DateOfInterest] DATE
+);
+
+INSERT INTO #DatesOfInterest
+VALUES ('2019-01-15'), ('2019-02-15'), ('2019-03-15'), ('2019-04-15'), ('2019-05-15'), ('2019-06-15'),
+	   ('2019-07-15'), ('2019-08-15'), ('2019-09-15'), ('2019-10-15'), ('2019-11-15'), ('2019-12-15'),
+	   ('2020-01-15'), ('2020-02-15'), ('2020-03-15'), ('2020-04-15'), ('2020-05-15'), ('2020-06-15'),
+	   ('2020-07-15'), ('2020-08-15'), ('2020-09-15'), ('2020-10-15'), ('2020-11-15'), ('2020-12-15'),
+	   ('2021-01-15'), ('2021-02-15'), ('2021-03-15'), ('2021-04-15'), ('2021-05-15'), ('2021-06-15'),
+	   ('2021-07-15'), ('2021-08-15'), ('2021-09-15'), ('2021-10-15'), ('2021-11-15'), ('2021-12-15'),
+	   ('2022-01-15'), ('2022-02-15'), ('2022-03-15'), ('2022-04-15'), ('2022-05-15'), ('2022-06-15'),
+		 ('2022-07-15'), ('2022-08-15'), ('2022-09-15'), ('2022-10-15'), ('2022-11-15'), ('2022-12-15'),
+		 ('2023-01-15'), ('2023-02-15'), ('2023-03-15'), ('2023-04-15'), ('2023-05-15'), ('2023-06-15'),
+		 ('2023-07-15'), ('2023-08-15'), ('2023-09-15'), ('2023-10-15'), ('2023-11-15'), ('2023-12-15'),
+		 ('2024-01-15'), ('2024-02-15'), ('2024-03-15'), ('2024-04-15'), ('2024-05-15');
+
+
+-- Create a table of all patients with start date and end date in GP history table================================================================================================================
+IF OBJECT_ID('tempdb..#GPHistory') IS NOT NULL DROP TABLE #GPHistory;
+SELECT FK_Patient_Link_ID, StartDate, EndDate, GPPracticeCode
+INTO #GPHistory
+FROM SharedCare.Patient_GP_History
+WHERE FK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients);
+
+
+-- Merge with death date=========================================================================================================================================================================
+IF OBJECT_ID('tempdb..#Table') IS NOT NULL DROP TABLE #Table;
+SELECT h.FK_Patient_Link_ID, h.GPPracticeCode, h.StartDate, h.EndDate, l.DeathDate
+INTO #Table
+FROM #GPHistory h
+LEFT OUTER JOIN [RLS].[vw_Patient_Link] l ON h.FK_Patient_Link_ID = l.PK_Patient_Link_ID;
+
+
+-- Update the table with death date information===========================================================================================================
+UPDATE
+#Table
+SET
+EndDate = DeathDate
+WHERE
+EndDate IS NULL OR DeathDate < EndDate;
+
+
+UPDATE
+#Table
+SET
+StartDate = DeathDate
+WHERE
+DeathDate < StartDate;
+
+
+-- For each patient with a matching registration period for each date of interest, we find
+-- the most recent start date (NB this can match multiple rows for each patient and each date of interest)
+IF OBJECT_ID('tempdb..#MostRecentStartDates') IS NOT NULL DROP TABLE #MostRecentStartDates;
+SELECT FK_Patient_Link_ID, DateOfInterest, MAX(StartDate) AS LatestStartDate INTO #MostRecentStartDates
+FROM #Table h
+INNER JOIN #DatesOfInterest d ON CAST(StartDate AS DATE) <= d.DateOfInterest AND (EndDate IS NULL OR CAST(EndDate AS DATE) >= d.DateOfInterest)
+WHERE GPPracticeCode IS NOT NULL
+GROUP BY FK_Patient_Link_ID, DateOfInterest;
+-- 3m29
+
+
+-- We now link the patient ids and start dates back to the GP_History table, so that for cases
+-- where a patient has multiple startdates, we can pick the one with the furthest end date. (NB
+-- this can still lead to multiple rows for each patient and each date of interest)
+IF OBJECT_ID('tempdb..#FurthestEndDates') IS NOT NULL DROP TABLE #FurthestEndDates;
+SELECT h.FK_Patient_Link_ID, DateOfInterest, StartDate, MAX(CASE WHEN EndDate IS NULL THEN '2100-01-01' ELSE EndDate END) AS LatestEndDate INTO #FurthestEndDates
+FROM #Table h
+INNER JOIN #MostRecentStartDates m 
+       ON m.FK_Patient_Link_ID = h.FK_Patient_Link_ID
+       AND m.LatestStartDate = StartDate
+       AND (EndDate IS NULL OR CAST(EndDate AS DATE) >= DateOfInterest)
+GROUP BY h.FK_Patient_Link_ID, DateOfInterest, StartDate;
+-- 2m23
+
+
+-- Bring it all together into a table that shows which practice each person was at
+-- for each date of interest
+IF OBJECT_ID('tempdb..#PatientGPPracticesOnDate') IS NOT NULL DROP TABLE #PatientGPPracticesOnDate;
+SELECT h.FK_Patient_Link_ID, MAX(GPPracticeCode) AS GPPracticeCode, YEAR (DateOfInterest) AS Year, MONTH (DateOfInterest) AS Month, DAY(DateOfInterest) AS Day
+INTO #PatientGPPracticesOnDate
+FROM #Table h
+INNER JOIN #FurthestEndDates f
+       ON f.FK_Patient_Link_ID = h.FK_Patient_Link_ID
+       AND f.StartDate = h.StartDate
+       AND (
+             f.LatestEndDate = h.EndDate 
+             OR (h.EndDate IS NULL AND f.LatestEndDate='2100-01-01')
+       )
+WHERE GPPracticeCode IS NOT NULL
+GROUP BY h.FK_Patient_Link_ID, DateOfInterest;
+
+
+-- Create the table of ethnic================================================================================================================================
+IF OBJECT_ID('tempdb..#Ethnicities') IS NOT NULL DROP TABLE #Ethnicities;
+SELECT 
+  PK_Patient_Link_ID AS FK_Patient_Link_ID,
+  CASE 
+    WHEN EthnicMainGroup IS NULL THEN 'Refused and not stated group'
+    ELSE EthnicMainGroup
+  END AS Ethnicity
+INTO #Ethnicities
+FROM SharedCare.Patient_Link
+WHERE PK_Patient_Link_ID IN (SELECT FK_Patient_Link_ID FROM #Patients);
+
+
+
+-- Create the table of IDM================================================================================================================================
+IF OBJECT_ID('tempdb..#IMDGroup') IS NOT NULL DROP TABLE #IMDGroup;
+SELECT FK_Patient_Link_ID, IMDGroup = CASE 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (1,2) THEN 1 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (3,4) THEN 2 
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (5,6) THEN 3
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (7,8) THEN 4
+		WHEN IMD2019Decile1IsMostDeprived10IsLeastDeprived IN (9,10) THEN 5
+		ELSE NULL END
+INTO #IMDGroup
+FROM #PatientIMDDecile;
+
+
+-- Merge CCG information============================================================================================================================================
+IF OBJECT_ID('tempdb..#FinalTable') IS NOT NULL DROP TABLE #FinalTable;
+SELECT p.FK_Patient_Link_ID, 
+	p.GPPracticeCode, 
+	p.Year, 
+	p.Month,
+	p.Day,
+	ISNULL(ccg.CcgName, '') AS CCG, 
+	Sex,
+	Ethnicity,
+	(p.Year - YearOfBirth) AS Age,
+  	IMDGroup
+INTO #FinalTable
+FROM #PatientGPPracticesOnDate p
+LEFT OUTER JOIN SharedCare.Reference_GP_Practice gp ON gp.OrganisationCode = p.GPPracticeCode
+LEFT OUTER JOIN #CCGLookup ccg ON ccg.CcgId = gp.Commissioner
+LEFT OUTER JOIN #Ethnicities e ON e.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientYearOfBirth yob ON yob.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #PatientSex sex ON sex.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+LEFT OUTER JOIN #IMDGroup imd ON imd.FK_Patient_Link_ID = p.FK_Patient_Link_ID
+WHERE Sex != 'U';
+
+
+-- Count============================================================================================================================================================
+SELECT Year, Month, Sex, Age, Ethnicity, IMDGroup, CCG, GPPracticeCode AS GPPracticeId, 
+	   SUM(CASE WHEN Day IS NOT NULL THEN 1 ELSE 0 END) AS NumberOfPatients
+FROM #FinalTable
+WHERE Year = 2024 AND Month = 3
+GROUP BY Year, Month, Age, Sex, Ethnicity, IMDGroup, GPPracticeCode, CCG
+ORDER BY Year, Month, Age, Sex, Ethnicity, IMDGroup, GPPracticeCode, CCG;
+


### PR DESCRIPTION
**all queries**
- use SuppliedCode instead of FK ids
- cast dates in #GPEvents and #GPMedications creation rather in their usage
- removed post-COPI date filtering

**scripts.sql**
- truncate to just <25 yr olds in 2019 early to improve speed
- only calculate year and month (not individual days)
- class NULL ethnicity as 'Refused and not stated'
- fixed joins at the end: the #First...Counts tables returned multiple rows if a person had more than one event in a month. This messed up the query a bit as the other sums were then double counting. By changing the #First...Counts tables so that for each patient, year and month there is just one row with the number of occurrences that month (Frequency), we can join without problem and sum the Frequency column

**events & medication helpers**
- calculate year and month (instead of the actual date) here for the #First...Counts table instead of main query and sum over each patient, year and month to get the frequency rather than having multiple rows for a patient in the same month

